### PR TITLE
Se actualizó PDFBox a su versión 2.0.8 desde la versión 1.8.12.

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -399,10 +399,6 @@
            <artifactId>fontbox</artifactId>
         </dependency>
         <dependency>
-           <groupId>org.apache.pdfbox</groupId>
-           <artifactId>jempbox</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15</artifactId>
         </dependency>

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/PDFFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/PDFFilter.java
@@ -18,7 +18,8 @@ import java.io.Writer;
 
 import org.apache.log4j.Logger;
 import org.apache.pdfbox.pdmodel.PDDocument;
-import org.apache.pdfbox.util.PDFTextStripper;
+import org.apache.pdfbox.text.PDFTextStripper;
+import org.dspace.content.Item;
 import org.dspace.core.ConfigurationManager;
 
 /*

--- a/dspace-api/src/main/java/org/dspace/content/packager/PDFPackager.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/PDFPackager.java
@@ -20,6 +20,9 @@ import org.apache.commons.lang.ArrayUtils;
 import org.apache.log4j.Logger;
 import org.apache.pdfbox.cos.COSDocument;
 import org.apache.pdfbox.pdfparser.PDFParser;
+import org.apache.pdfbox.io.ScratchFile;
+import org.apache.pdfbox.io.MemoryUsageSetting;
+import org.apache.pdfbox.io.RandomAccessBufferedFileInputStream;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDDocumentInformation;
 import org.dspace.authorize.AuthorizeException;
@@ -294,7 +297,18 @@ public class PDFPackager
 
         try
         {
-            PDFParser parser = new PDFParser(metadata);
+            ScratchFile scratchFile = null;
+            try
+            {
+                long useRAM = Runtime.getRuntime().freeMemory()*80/100; // use up to 80% of JVM free memory
+                scratchFile = new ScratchFile(MemoryUsageSetting.setupMixed(useRAM)); // then fallback to temp file (unlimited size)
+            }
+            catch (IOException ioe)
+            {
+                log.warn("Error initializing scratch file: " + ioe.getMessage());
+            }
+        
+            PDFParser parser = new PDFParser(new RandomAccessBufferedFileInputStream(metadata), scratchFile);
             parser.parse();
             cos = parser.getDocument();
 

--- a/pom.xml
+++ b/pom.xml
@@ -1059,17 +1059,12 @@
          <dependency>
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>pdfbox</artifactId>
-            <version>1.8.12</version>
+            <version>2.0.8</version>
          </dependency>
          <dependency>
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>fontbox</artifactId>
-            <version>1.8.12</version>
-         </dependency>
-         <dependency>
-            <groupId>org.apache.pdfbox</groupId>
-            <artifactId>jempbox</artifactId>
-            <version>1.8.12</version>
+            <version>2.0.8</version>
          </dependency>
          <dependency>
 	        <groupId>org.bouncycastle</groupId>


### PR DESCRIPTION
**Ticket**: http://trac.prebi.unlp.edu.ar/issues/4663

Se tuvo que hacer un **backport** de los siguientes commits en la rama DSpace 6.x de DSpace/DSpace
* 0776a2622ffbbf87a1a9358d49cf536568df92d8
DS-3035 upgrade to PDFBox 2 (code builds, not tested)
* 9d43d74d84d838d4257a8d64a94f45a32c2fe693
mem limit: hardcoded -> automatically adjusting
* 911dfae7fbdfc70f1ff51ba0966f752c335b883f
DS-3035 PDFBox 2.0.0-RC3 -> 2.0.0

*NOTA*: Se tuvo que modificar el backport para que funcione en DSpace 5.X, ya que los commits  "cherypickeados" son para DSpace 6.x. Las clases principalmente involucradas en la modificación son PDFPackager.java (ya que en la nueva version de pdfbox existen nuevas clases que deben ser actualizadas en DSpace) y CitationDocument.java (CitationDocumentServiceImpl.java en DSpace 6.x) (ya que en DSpace 6.x esta clase es un servicio y en DSpace 5.x es un Manager.