### PR TITLE
Simplicar get sparql search by id query

### DIFF
--- a/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/AuthorAuthority.java
+++ b/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/AuthorAuthority.java
@@ -57,18 +57,12 @@ public class AuthorAuthority extends AdvancedSPARQLAuthorityProvider {
 		pqs.setNsPrefix("rdf", NS_RDF);
 		pqs.setNsPrefix("sioc", NS_SIOC);
 
-		pqs.setCommandText("CONSTRUCT { ?person a foaf:Person. ?person foaf:givenName ?name . ?person foaf:mbox ?mail . ?person foaf:surname ?surname. ?person cerif:linksToOrganisationUnit ?link . ?link cerif:startDate ?inicio. ?link cerif:endDate ?fin . ?link foaf:Organization ?org . ?org foaf:name ?affiliation. ?org sioc:id ?id. }\n");
+		pqs.setCommandText("CONSTRUCT { ?person a foaf:Person. ?person foaf:givenName ?name . ?person foaf:surname ?surname . }\n");
 		pqs.append("WHERE {\n");
 		pqs.append("?person a foaf:Person ; foaf:givenName ?name ; foaf:surname ?surname .\n");
-		pqs.append("	OPTIONAL {\n");
-		pqs.append("	?person foaf:mbox ?mail . \n");
-		pqs.append("	} . \n");
-		pqs.append("	OPTIONAL {\n");
-		pqs.append("	?person cerif:linksToOrganisationUnit ?link . ?link cerif:startDate ?inicio; cerif:endDate ?fin; foaf:Organization ?org . ?org foaf:name ?affiliation; sioc:id ?id\n");
-		pqs.append("	}\n");
 		pqs.append("FILTER(REGEX(?person, ?key, \"i\"))\n");
 		pqs.append("}\n");
-		pqs.append("ORDER BY ?surname ?link\n");
+		pqs.append("ORDER BY ?surname \n");
 
 		pqs.setLiteral("key", key);
 		return pqs;

--- a/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/InstitutionAuthority.java
+++ b/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/InstitutionAuthority.java
@@ -14,13 +14,11 @@ public class InstitutionAuthority extends SimpleSPARQLAuthorityProvider {
 		pqs.setNsPrefix("foaf", NS_FOAF);
 		pqs.setNsPrefix("dc", NS_DC);
 		pqs.setNsPrefix("sioc", NS_SIOC);
-		pqs.setNsPrefix("skos", NS_SKOS);
 
-		pqs.setCommandText("SELECT ?institution ?label ?initials ?labelpadre ?initpadre \n");
+		pqs.setCommandText("SELECT ?institution ?label ?initials \n");
 		pqs.append("WHERE {\n");
 		pqs.append("?institution a foaf:Organization ; foaf:name ?label .\n");
 		pqs.append("OPTIONAL { ?institution sioc:id ?initials} . \n");
-		pqs.append("OPTIONAL { ?institution skos:broader ?padre . ?padre foaf:name ?labelpadre  OPTIONAL { ?padre sioc:id  ?initpadre } . } \n");    
 		pqs.append("FILTER(REGEX(?institution, ?key, \"i\"))\n");
 		pqs.append("}\n");
 

--- a/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/InstitutionAuthority.java
+++ b/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/InstitutionAuthority.java
@@ -13,12 +13,10 @@ public class InstitutionAuthority extends SimpleSPARQLAuthorityProvider {
 
 		pqs.setNsPrefix("foaf", NS_FOAF);
 		pqs.setNsPrefix("dc", NS_DC);
-		pqs.setNsPrefix("sioc", NS_SIOC);
 
-		pqs.setCommandText("SELECT ?institution ?label ?initials \n");
+		pqs.setCommandText("SELECT ?institution ?label \n");
 		pqs.append("WHERE {\n");
 		pqs.append("?institution a foaf:Organization ; foaf:name ?label .\n");
-		pqs.append("OPTIONAL { ?institution sioc:id ?initials} . \n");
 		pqs.append("FILTER(REGEX(?institution, ?key, \"i\"))\n");
 		pqs.append("}\n");
 


### PR DESCRIPTION
Al momento de indexar, solr arma para cada autoridad un label. Se simplifico el armado del mismo, quitando las filiaciones entre parentesis, en el caso de los autores, y las siglas entre paréntesis en el caso de las instituciones.
Con esto también se evitan duplicados en el browse de autores, ya que si a un autor indexado se le agrega un institución, se generara un nuevo label. Por ejemplo

Si a Juan Martinez (UNLP), le agrego otra filiación como CONICET, en el browse de autores va a aparecer

Juan Martínez (UNLP) y Juan Martinez (UNLP, CONICET)

Al menos hasta reindexar sorl (lo cual no estaría bien)