### PR TITLE
4764 agrego cron de voc.sedici

### DIFF
--- a/dspace/config/cron.d-backups-sedici
+++ b/dspace/config/cron.d-backups-sedici
@@ -53,7 +53,7 @@ MYSQL_sedici_dspace_PWD='XXX'
 ##################################################################################
 
 #backups de drupal para autoridades (de lunes a viernes a las 4:50AM)
-50 4 * * 1,2,3,4,5	root	drush -r /var/www/auth archive-dump --destination=$DSPACE_BACKUP_DIR/auth/auth.$($DATESTR).tar.gz -q > /dev/null
+50 4 * * 1,2,3,4,5	root	/usr/local/bin/drush -r /var/www/auth archive-dump --destination=$DSPACE_BACKUP_DIR/auth/auth.$($DATESTR).tar.gz -q > /dev/null
 
 #rotación de backups de drupal (todos los dias a las 05:00hs). Se eliminan aquellos mas antiguos a 30 dias de creación pero se conservan los de primero de cada mes
 0 5 * * 1,2,3,4,5       root  find $DSPACE_BACKUP_DIR/auth -maxdepth 1 -name "auth.*.tar.gz" -mtime +30 -not -name "auth.20??-??-01*.tar.gz" -exec rm {} \; > /dev/null

--- a/dspace/config/cron.d-backups-sedici
+++ b/dspace/config/cron.d-backups-sedici
@@ -48,4 +48,13 @@ MYSQL_sedici_dspace_PWD='XXX'
 #MYSQL_sedici_blog_PWD='YYY'
 #30 16 * * 1,2,3,4,5	root	mysqldump -usedici_blog -p$MYSQL_sedici_blog_PWD -hdata.server.sedici.unlp.edu.ar sedici_blog2 | gzip -c > $DSPACE_BACKUP_DIR/mysql/sedici_blog2.sql.gz
 
+##################################################################################
+##  AUTH AUTH AUTH AUTH AUTH AUTH AUTH AUTH AUTH AUTH AUTH AUTH AUTH AUTH AUTH ##
+##################################################################################
+
+#backups de drupal para autoridades (de lunes a viernes a las 4:50AM)
+50 4 * * 1,2,3,4,5	root	drush -r /var/www/auth archive-dump --destination=$DSPACE_BACKUP_DIR/auth/auth.$($DATESTR).tar.gz -q > /dev/null
+
+#rotación de backups de drupal (todos los dias a las 05:00hs). Se eliminan aquellos mas antiguos a 30 dias de creación pero se conservan los de primero de cada mes
+0 5 * * 1,2,3,4,5       root  find $DSPACE_BACKUP_DIR/auth -maxdepth 1 -name "auth.*.tar.gz" -mtime +30 -not -name "auth.20??-??-01*.tar.gz" -exec rm {} \; > /dev/null
 


### PR DESCRIPTION
Agrego la cron para hacer backup de codigo y base de datos de voc.sedici mediante drush, junto con rotación. Misma política que CIC-DIGITAL.
