### PR TITLE
4755 agrego comparator de label

### DIFF
--- a/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/AdvancedSPARQLAuthorityProvider.java
+++ b/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/AdvancedSPARQLAuthorityProvider.java
@@ -1,6 +1,7 @@
 package ar.edu.unlp.sedici.dspace.authority;
 
 
+import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -30,6 +31,15 @@ public abstract class AdvancedSPARQLAuthorityProvider extends SPARQLAuthorityPro
 		while (RDFResources.hasNext()){
 			choices.add(this.extractChoice(RDFResources.next()));
 		};		
+		choices.sort(new Comparator<Choice>() {
+		    @Override
+		    public int compare(Choice m1, Choice m2) {
+		        if(m1.label == m2.label){
+		            return 0;
+		        }
+		        return m1.label.compareTo(m2.label) < 0 ? -1 : 1;
+		     }
+		});
 		return choices.toArray(new Choice[0]);
 	}
 

--- a/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/AuthorAuthority.java
+++ b/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/AuthorAuthority.java
@@ -101,7 +101,7 @@ public class AuthorAuthority extends AdvancedSPARQLAuthorityProvider {
 			if (tokens.length > 1 && tokens[0].trim().length() > 0 && tokens[1].trim().length() > 0) {
 				pqs.append("FILTER(REGEX(?name, ?text2, \"i\") && REGEX(?surname, ?text1, \"i\"))\n");
 				pqs.setLiteral("text1", tokens[0].trim());
-				pqs.setLiteral("text2", tokens[1].trim());
+				pqs.setLiteral("text2", "^" + tokens[1].trim());
 			} else {
 				pqs.append("FILTER(REGEX(?name, ?text, \"i\") || REGEX(?surname, ?text, \"i\") || REGEX(?id, ?text, \"i\"))\n");
 				pqs.setLiteral("text", tokens[0]);


### PR DESCRIPTION
El grafo que se recupera con SPARQL viene desordenado, entonces una vez instanciado los choices y habiéndolos guardado en un arreglo, se los ordena. Se puede chequera durante el submission, al consultar por autor.