### PR TITLE
-#4819 Ahora las instituciones se guardan en la BBDD sin las iniciales

### DIFF
--- a/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/InstitutionAuthority.java
+++ b/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/InstitutionAuthority.java
@@ -53,6 +53,7 @@ public class InstitutionAuthority extends SimpleSPARQLAuthorityProvider {
 	protected Choice extractChoice(QuerySolution solution) {
 		String key = solution.getResource("institution").getURI();
 		String label = "";
+		String value = solution.getLiteral("label").getString();
 		if (solution.contains("labelpadre") && !"".equals(solution.getLiteral("labelpadre").getString())) {
 			label += solution.getLiteral("labelpadre").getString();
 			if (solution.contains("initpadre") && !"".equals(solution.getLiteral("initpadre").getString())) {
@@ -62,13 +63,12 @@ public class InstitutionAuthority extends SimpleSPARQLAuthorityProvider {
 			label += " - ";
 		}
 		label += solution.getLiteral("label").getString();
-		
 		if (solution.contains("initials") && !"".equals(solution.getLiteral("initials").getString())) {
 			String initials = solution.getLiteral("initials").getString();
 			label += " (" + initials + ")";
 		}
 
 
-		return new Choice(key, label, label);
+		return new Choice(key, value, label);
 	}
 }


### PR DESCRIPTION
El InstitutionAuthority fue modificado para que en el value de las Choices no devuelva
las iniciales entre paréntesis, y que solamente lo haga en el label.