### PR TITLE
#3654 Algunos cambios mas relativos al cambio de iconos confidence

### DIFF
--- a/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/InstitutionAuthority.java
+++ b/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/InstitutionAuthority.java
@@ -41,7 +41,7 @@ public class InstitutionAuthority extends SimpleSPARQLAuthorityProvider {
 		pqs.append("OPTIONAL { ?institution skos:broader ?padre . ?padre foaf:name ?labelpadre  OPTIONAL { ?padre sioc:id  ?initpadre } . } \n");    
 		if (!"".equals(text)) {
 			pqs.append("FILTER(REGEX(?label, ?text, \"i\") || REGEX(?initials, ?text, \"i\"))\n");
-			pqs.setLiteral("text", text);
+			pqs.setLiteral("text", text.trim());
 		}
 		pqs.append("}\n");
 		pqs.append("ORDER BY ASC(?label)\n");

--- a/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/TesauroAuthority.java
+++ b/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/TesauroAuthority.java
@@ -60,8 +60,8 @@ public class TesauroAuthority extends SimpleSPARQLAuthorityProvider {
 		pqs.append("WHERE {\n");
 		pqs.append("?term a "+ rdfType +"; skos:prefLabel ?label .\n");
 		pqs.append("OPTIONAL { ?term skos:broader ?parent . ?parent skos:prefLabel ?parentLabel } \n");
-		if (!"".equals(text)) {
-			pqs.append("FILTER(REGEX(?label, '"+text+"', 'i'))\n");
+		if (!"".equals(text.trim())) {
+			pqs.append("FILTER(REGEX(?label, '"+text.trim()+"', 'i'))\n");
 		}
 		pqs.append("}\n");
 		pqs.append("ORDER BY ASC(?label)\n");

--- a/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/js/choice-support-administrator.js
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/js/choice-support-administrator.js
@@ -69,7 +69,7 @@
 
 function verificarConfianzaInicial(inputID, authorityLabelID, confidenceIndicatorID, confidenceName){
 	if ($('#'+confidenceName).val()==confianza_600){ 
-		if ($('#'+inputID).val()!=$('#'+authorityLabelID).val()){
+		if ($('#'+inputID).val().trim()!=$('#'+authorityLabelID).val().trim()){
 			//Variante
 			DSpaceUpdateConfidence(document, confidenceIndicatorID, icono_accepted_variant);
 		}
@@ -210,8 +210,12 @@ function DSpaceSetupAutocomplete(formID, args) {
                 			//pero es tratado dependiendo si es authority controlled y si ya existe cargada una authority key
                 			if (isAuthorityControlled){                        		
                         		if ($('#' + authorityID).val() != ''){   
-                        			//en este caso es una variacion de un authority key
-                        			cambiarAuthority(inputID, authorityID, $('#' + authorityID).val(), args.confidenceIndicatorID, icono_accepted_variant, args.confidenceName, confianza_600, null, null);
+                        			if ($('#'+inputID).val().trim()==$('#' + authorityLabelID).val().trim()){
+                        				cambiarAuthority(inputID, authorityID, $('#' + authorityID).val(), args.confidenceIndicatorID, icono_accepted, args.confidenceName, confianza_600, null, null);
+                        			} else {
+                        				//en este caso es una variacion de un authority key
+                        				cambiarAuthority(inputID, authorityID, $('#' + authorityID).val(), args.confidenceIndicatorID, icono_accepted_variant, args.confidenceName, confianza_600, null, null);
+                        			}
                         		 } else {
                         			//es un nuevo elemento
      	            				cambiarAuthority(inputID, authorityID, '', args.confidenceIndicatorID, icono_new, args.confidenceName, confianza_300, null, null);
@@ -223,10 +227,14 @@ function DSpaceSetupAutocomplete(formID, args) {
                         } else {
                         	if (isAuthorityControlled){                        		
                         		if ($('#' + authorityID).val() != ''){
-                        			//en este caso es una variacion de un authority key
-                        			//permito agregar variante porque estoy sobre un authority cerrado
-                        			//en este caso es una variacion de un authority key
-                        			cambiarAuthority(inputID, authorityID, $('#' + authorityID).val(), args.confidenceIndicatorID, icono_accepted_variant, args.confidenceName, confianza_600, null, null);
+                        			if ($('#'+inputID).val().trim()==$('#' + authorityLabelID).val().trim()){
+                        				cambiarAuthority(inputID, authorityID, $('#' + authorityID).val(), args.confidenceIndicatorID, icono_accepted, args.confidenceName, confianza_600, null, null);
+                        			} else {
+                        				//en este caso es una variacion de un authority key
+                        				//permito agregar variante porque estoy sobre un authority cerrado
+                        				//en este caso es una variacion de un authority key
+                        				cambiarAuthority(inputID, authorityID, $('#' + authorityID).val(), args.confidenceIndicatorID, icono_accepted_variant, args.confidenceName, confianza_600, null, null);
+                        			}
                         		} else {
                         			//Como es cerrado y no tengo selecionado un authority key freno las tratativas
         	                    	cambiarAuthority(inputID, authorityID, $('#' + authorityID).val(), args.confidenceIndicatorID, icono_rejected, args.confidenceName, confianza_100, null, null);
@@ -261,8 +269,12 @@ function DSpaceSetupAutocomplete(formID, args) {
 	            	if (isClosed){
 	            		if (isAuthorityControlled){
 	            			if ($('#' + authorityID).val() != ''){
-	            				//en este caso es una variacion de un authority key
-	            				cambiarAuthority(inputID, authorityID, $('#' + authorityID).val(), args.confidenceIndicatorID, icono_accepted_variant, args.confidenceName, confianza_600, null, null);
+	            				if ($('#'+inputID).val().trim()==$('#' + authorityLabelID).val().trim()){
+	            					cambiarAuthority(inputID, authorityID, $('#' + authorityID).val(), args.confidenceIndicatorID, icono_accepted, args.confidenceName, confianza_600, null, null);
+	            				}else{
+	            					//en este caso es una variacion de un authority key
+	            					cambiarAuthority(inputID, authorityID, $('#' + authorityID).val(), args.confidenceIndicatorID, icono_accepted_variant, args.confidenceName, confianza_600, null, null);
+	            				}
 		            		} else {
 	            				//No hay authority key, por lo que debo notificar del error
 		            			cambiarAuthority(inputID, authorityID, $('#' + authorityID).val(), args.confidenceIndicatorID, icono_rejected, args.confidenceName, confianza_100, null, null);
@@ -277,7 +289,7 @@ function DSpaceSetupAutocomplete(formID, args) {
 	            	} else {
 	            		if (isAuthorityControlled){
 	            			if ($('#' + authorityID).val() != ''){
-	            				if ($('#'+inputID).val()==$('#' + authorityLabelID).val()){
+	            				if ($('#'+inputID).val().trim()==$('#' + authorityLabelID).val().trim()){
 	            					//eesto esta al pedo, es por el plugvin de dias
 		            				cambiarAuthority(inputID, authorityID, $('#' + authorityID).val(), args.confidenceIndicatorID, icono_accepted, args.confidenceName, confianza_600, null, null);
 	            				} else {

--- a/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/js/choice-support.js
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/js/choice-support.js
@@ -43,7 +43,7 @@ function cambiarAuthority(inputID, authorityID, authorityValue, confidenceIndica
 	cambiarAuthorityConfidence(confidenceNameID, confidenceNameValue);
 	DSpaceUpdateConfidence(document, confidenceIndicatorID, confidenceIndicatorValue);
 	if (authorityLabelID != null){
-		if ($('#'+inputID).val()!=$('#' + authorityLabelID).val()){
+		if ($('#'+inputID).val().trim()!=$('#' + authorityLabelID).val().trim()){
 			$('#' + authorityLabelID).show();
 		}else{
 			$('#' + authorityLabelID).hide();


### PR DESCRIPTION
Continuación de los cambios aceptados en #14.

Se hace un `trim()` cada vez que se realizan comparaciones del texto ingresado por el usuario y el label devuelto por un Authority. De esta forma, se evitan detección errónea de variantes en casos como: _**"UNLP    "** comparado con **"UNLP"**_. Anteriormente, esta comparación se detectaba como variante.

Además se agregó un `trim()` en los choice authorities de **InstitutionAuthority** y **TesauroAuthority** para que no considere los espacios finales e iniciales al consultar a la base de autoridades en Drupal.

![authorities_confidence_example_trim](https://user-images.githubusercontent.com/6214284/45172489-dd169900-b1db-11e8-8440-1e7e455571f1.gif)