### PR TITLE
Agregar atributo "scope" para los steps en el Submission -#4832 -#4829

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/SubmissionConfigReader.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/SubmissionConfigReader.java
@@ -503,8 +503,7 @@ public class SubmissionConfigReader
                         if (stepScope != null && stepScope.length() > 0)
                         {
                             //If the "scope" attribute exists, then copy the stepInfo Map to avoid modifying the original declaration of the step in the step-definitions section.
-                            HashMap<String, String> stepInfoCopy = new HashMap<String,String>(stepInfo);
-                            stepInfo = stepInfoCopy;
+                            stepInfo = new HashMap<String,String>(stepInfo);
                             stepInfo.put("scope", stepScope);
                         }
 

--- a/dspace-api/src/main/java/org/dspace/app/util/SubmissionConfigReader.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/SubmissionConfigReader.java
@@ -497,6 +497,16 @@ public class SubmissionConfigReader
                             stepInfo = processStepChildNodes(
                                     "submission-process", nStep);
                         }
+                        
+                        //Check if nStep has an "scope" attribute. If true, overwrite any "scope" attribute declared in the step-definitions section.
+                        String stepScope = getAttribute(nStep, "scope");
+                        if (stepScope != null && stepScope.length() > 0)
+                        {
+                            //If the "scope" attribute exists, then copy the stepInfo Map to avoid modifying the original declaration of the step in the step-definitions section.
+                            HashMap<String, String> stepInfoCopy = new HashMap<String,String>(stepInfo);
+                            stepInfo = stepInfoCopy;
+                            stepInfo.put("scope", stepScope);
+                        }
 
                         steps.add(stepInfo);
 
@@ -569,6 +579,14 @@ public class SubmissionConfigReader
         if (stepID != null && stepID.length() > 0)
         {
             stepInfo.put("id", stepID);
+        }
+        
+        //Check for SCOPE specifications. The values accepted for this attribute must be some of the constants declared in the Constants.actionText array definition.
+        //The scope can be negated using the "!" symbol.
+        String stepScope = getAttribute(nStep, "scope");
+        if (stepScope != null && stepScope.length() > 0)
+        {
+            stepInfo.put("scope", stepScope);
         }
 
         // look for REQUIRED 'step' information

--- a/dspace-api/src/main/java/org/dspace/app/util/SubmissionInfo.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/SubmissionInfo.java
@@ -744,7 +744,7 @@ public class SubmissionInfo extends HashMap
     	int actionID = Constants.getActionID(step.getScope());
     	String collectionHandle = subItem.getCollection().getHandle();
     	if(actionID != -1) {
-    		//Detect if we have the specified permission of action over the owner of the Item being submitted.
+    		//Detect if we have the specified permission of action over the owner collection of the Item being submitted.
     		Collection inSubmissionCollection = (Collection)HandleManager.resolveToObject(context, collectionHandle);
     		boolean isAuthorized = AuthorizeManager.authorizeActionBoolean(context, inSubmissionCollection, actionID, true);
     		return (step.isDenyScope())

--- a/dspace-api/src/main/java/org/dspace/app/util/SubmissionStepConfig.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/SubmissionStepConfig.java
@@ -8,7 +8,14 @@
 package org.dspace.app.util;
 
 import java.util.Map;
+
+import org.dspace.authorize.AuthorizeManager;
+import org.dspace.content.Item;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+
 import java.io.Serializable;
+import java.sql.SQLException;
 
 /**
  * Class representing configuration for a single step within an Item Submission
@@ -42,6 +49,17 @@ public class SubmissionStepConfig implements Serializable
      * <step-definitions> section)
      */
     private String id = null;
+    
+    /**
+     * The scope where this step can be executed (i.e. a step can be executed 
+     * when current user has ADMIN permission over the item being processed...).
+     */
+    private String scope = null;
+    
+    /**
+     * Determine if the current scope expression must be denied or not.
+     */
+    private boolean denyScope = false;
 
     /** the heading for this step */
     private String heading = null;
@@ -96,6 +114,16 @@ public class SubmissionStepConfig implements Serializable
         {
             workflowEditable = Boolean.parseBoolean(wfEditString);
         }
+        
+        String tmpScope = stepMap.get("scope");
+        if (tmpScope != null && tmpScope.length() > 0) {
+        	tmpScope = tmpScope.trim();
+        	if(tmpScope.startsWith("!")) {
+        		denyScope = true;
+        		tmpScope = tmpScope.substring(1).trim();
+        	} //By the default, the scope is not denied...
+        	scope = tmpScope;
+        }
     }
 
     /**
@@ -109,8 +137,24 @@ public class SubmissionStepConfig implements Serializable
     {
         return id;
     }
+    
+	/**
+	 * Get the scope of this step.
+	 * @return the scope
+	 */
+	public String getScope() {
+		return scope;
+	}
 
-    /**
+	/**
+	 * Returns true if the scope condi.
+	 * @return the denyScope
+	 */
+	public boolean isDenyScope() {
+		return denyScope;
+	}
+
+	/**
      * Get the heading for this step. This can either be a property from
      * Messages.properties, or the actual heading text. If this "heading"
      * contains a period(.) it is assumed to reference Messages.properties.

--- a/dspace-api/src/main/java/org/dspace/app/util/SubmissionStepConfig.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/SubmissionStepConfig.java
@@ -121,7 +121,7 @@ public class SubmissionStepConfig implements Serializable
         	if(tmpScope.startsWith("!")) {
         		denyScope = true;
         		tmpScope = tmpScope.substring(1).trim();
-        	} //By the default, the scope is not denied...
+        	}
         	scope = tmpScope;
         }
     }
@@ -147,7 +147,7 @@ public class SubmissionStepConfig implements Serializable
 	}
 
 	/**
-	 * Returns true if the scope condi.
+	 * Returns true if the scope condition is denied (specified with the "!" symbol).
 	 * @return the denyScope
 	 */
 	public boolean isDenyScope() {

--- a/dspace-api/src/main/java/org/dspace/submit/step/SelectCollectionStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/SelectCollectionStep.java
@@ -111,7 +111,7 @@ public class SelectCollectionStep extends AbstractProcessingStep
 
             // need to reload current submission process config,
             // since it is based on the Collection selected
-            subInfo.reloadSubmissionConfig(request);
+            subInfo.reloadSubmissionConfig(request, context);
         }
 
         // no errors occurred

--- a/dspace-api/src/main/java/org/dspace/submit/step/StartSubmissionLookupStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/StartSubmissionLookupStep.java
@@ -272,7 +272,7 @@ public class StartSubmissionLookupStep extends AbstractProcessingStep
 
             // need to reload current submission process config,
             // since it is based on the Collection selected
-            subInfo.reloadSubmissionConfig(request);
+            subInfo.reloadSubmissionConfig(request, context);
         }
 
         slService.invalidateDTOs(request, uuidSubmission);

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/SubmissionController.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/SubmissionController.java
@@ -155,7 +155,7 @@ public class SubmissionController extends DSpaceServlet
                         .parseInt(workspaceID));
 
                 //load submission information
-                SubmissionInfo si = SubmissionInfo.load(request, wi);
+                SubmissionInfo si = SubmissionInfo.load(request, wi, context);
                 
                 //TD: Special case - If a user is resuming a submission
                 //where the submission process now has less steps, then
@@ -199,7 +199,7 @@ public class SubmissionController extends DSpaceServlet
                         .parseInt(workflowID));
 
                 //load submission information
-                SubmissionInfo si = SubmissionInfo.load(request, wi);
+                SubmissionInfo si = SubmissionInfo.load(request, wi, context);
                 
                 // start over at beginning of first workflow step
                 setBeginningOfStep(request, true);
@@ -1045,19 +1045,19 @@ public class SubmissionController extends DSpaceServlet
             {
                 int workflowID = UIUtil.getIntParameter(request, "workflow_id");
                 
-                info = SubmissionInfo.load(request, WorkflowItem.find(context, workflowID));
+                info = SubmissionInfo.load(request, WorkflowItem.find(context, workflowID), context);
             }
             else if(request.getParameter("workspace_item_id") != null)
             {
                 int workspaceID = UIUtil.getIntParameter(request,
                         "workspace_item_id");
                 
-                info = SubmissionInfo.load(request, WorkspaceItem.find(context, workspaceID));
+                info = SubmissionInfo.load(request, WorkspaceItem.find(context, workspaceID), context);
             }
             else
             {
                 //by default, initialize Submission Info with no item
-                info = SubmissionInfo.load(request, null);
+                info = SubmissionInfo.load(request, null, context);
             }
             
             // We must have a submission object if after the first step,

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/FlowUtils.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/FlowUtils.java
@@ -138,7 +138,7 @@ public class FlowUtils {
                     .get(HttpEnvironment.HTTP_REQUEST_OBJECT);
             
                 // load submission info
-                subInfo = SubmissionInfo.load(httpRequest, submission);
+                subInfo = SubmissionInfo.load(httpRequest, submission, context);
     
                 // Set the session ID
                 context.setExtraLogInfo("session_id="

--- a/dspace-xmlui/src/main/resources/aspects/Submission/submission.js
+++ b/dspace-xmlui/src/main/resources/aspects/Submission/submission.js
@@ -27,6 +27,7 @@ importClass(Packages.org.dspace.app.xmlui.utils.ContextUtil);
 importClass(Packages.org.dspace.app.xmlui.cocoon.HttpServletRequestCocoonWrapper);
 importClass(Packages.org.dspace.app.xmlui.aspect.submission.FlowUtils);
 importClass(Packages.org.dspace.app.xmlui.aspect.submission.StepAndPage);
+importClass(Packages.org.dspace.app.util.SubmissionInfo);
 
 importClass(Packages.org.dspace.app.util.SubmissionConfig);
 importClass(Packages.org.dspace.app.util.SubmissionConfigReader);
@@ -301,9 +302,12 @@ function submissionControl(collectionHandle, workspaceID, initStepAndPage)
 	  	//Load this step's configuration
 	  	var stepConfig = submissionInfo.getSubmissionConfig().getStep(step);
 
-    	//Pass it all the info it needs, including any response/error flags
-    	//in case an error occurred
-    	response_flag = doNextPage(collectionHandle, workspaceID, stepConfig, state.stepAndPage, response_flag);
+	  	//Send the current step to Cocoon for execute if the current user has permission to it...
+	  	if(SubmissionInfo.canExecuteStep(stepConfig,submissionInfo.getSubmissionItem(),getDSContext())){
+	  		//Pass it all the info it needs, including any response/error flags
+	  		//in case an error occurred
+	  		response_flag = doNextPage(collectionHandle, workspaceID, stepConfig, state.stepAndPage, response_flag);
+	  	}
 
     	var maxStep = FlowUtils.getMaximumStepReached(getDSContext(),workspaceID);
         var maxPage = FlowUtils.getMaximumPageReached(getDSContext(),workspaceID);

--- a/dspace/config/item-submission.dtd
+++ b/dspace/config/item-submission.dtd
@@ -20,7 +20,10 @@
  <!ELEMENT step-definitions (step+) >
  
  <!ELEMENT step (heading?, processing-class?, jspui-binding?, xmlui-binding?, workflow-editable?) >
- <!ATTLIST step id NMTOKEN #IMPLIED>
+ <!-- The "scope" attribute values must be an optional not ("!" symbol) an the folowings next values: [READ,ADD,DELETE,ADMIN]. In example: "!ADMIN", "!READ", "READ", etc.-->
+ <!ATTLIST step 
+ 			id NMTOKEN #IMPLIED
+ 			scope CDATA #IMPLIED>
  
  <!ELEMENT heading (#PCDATA) >
  <!ELEMENT processing-class (#PCDATA)>

--- a/dspace/config/item-submission.xml
+++ b/dspace/config/item-submission.xml
@@ -137,9 +137,18 @@
       <!--Step sediciUploadItem will be to Upload the item.-->
       <step id="sediciUploadItem">
         <heading>submit.progressbar.upload</heading>
+        <processing-class>org.dspace.submit.step.UploadStep</processing-class>
+        <jspui-binding>org.dspace.app.webui.submit.step.JSPUploadStep</jspui-binding>
+        <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.UploadStep</xmlui-binding>
+        <workflow-editable>true</workflow-editable>
+      </step>
+
+      <!--Step sediciUploadWithEmbargoItem will be to Upload the item.-->
+      <step id="sediciUploadWithEmbargoItem">
+        <heading>submit.progressbar.upload</heading>
         <processing-class>org.dspace.submit.step.UploadWithEmbargoStep</processing-class>
         <jspui-binding>org.dspace.app.webui.submit.step.JSPUploadWithEmbargoStep</jspui-binding>
-		<xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.UploadWithEmbargoStep</xmlui-binding>
+        <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.UploadWithEmbargoStep</xmlui-binding>
         <workflow-editable>true</workflow-editable>
       </step>
       
@@ -273,8 +282,8 @@
       <!--Step 2 will be to Describe the item.-->
       <step id="sediciDescribeItem"/>
           
-      <!--Step 3 will be to Upload the item-->
-      <step id="sediciUploadItem"/>
+      <!--Step 3 will be to Upload the item with embargo option-->
+      <step id="sediciUploadWithEmbargoItem"/>
      
       <!--Step 4 will be to Verify/Review everything -->
  	  <step id="sediciVerifyItem"/>
@@ -298,8 +307,11 @@
       <!--Step 2 will be to Describe the item.-->
       <step id="sediciDescribeItem"/>
           
-      <!--Step 3 will be to Upload the item-->
-      <step id="sediciUploadItem"/>
+      <!--Step 3a will be to Upload the item-->
+      <step id="sediciUploadItem" scope="!ADMIN"/>
+      
+      <!--Step 3b (Only For users with ADMINs permission) will be to Upload the item-->
+      <step id="sediciUploadWithEmbargoItem" scope="ADMIN"/>
      
       <!--Step 4 will be to Verify/Review everything -->
  	  <step id="sediciVerifyItem"/>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
@@ -739,7 +739,7 @@
     <message key="xmlui.Submission.submit.UploadStep.infoEmbargo">
    <b>Note:</b> If you need that your work keeps temporarily hidden, you may request its embargo by 3, 6, 12, 18 or 24 months starting from the date of presentation of the work.   
    The UNLP and repository of SEDICI fervently support the open access to the scientific-academic production and therefore <b>RECCOMEND NOT</b> apply this restriction unless it results strictly needed for pending patents, confidenciality conveins and similar situations. Have in mind that the deposit of your thesis into the repository not allow you to do derived publications with quality of inedit; a derived work is NOT the original work.
-   <br/>To apply this restriction, you will must attach over this step a note of embargo request that properly justify the request (see model <a href="http://sedici.unlp.edu.ar/blog/wp-content/uploads/2015/12/Modelo-nota-de-embargo.doc">Here</a>).
+   <br/>To apply this restriction, you will must attach over this step a note of embargo request that properly justify the request (see model <a href="http://blog.sedici.unlp.edu.ar/wp-content/uploads/sites/17/2018/09/Modelo-nota-de-embargo.doc">Here</a>).
    </message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.EditFileStep -->

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages_es.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages_es.xml
@@ -884,7 +884,7 @@
    convenios de confidencialidad y casos similares. Tenga en cuenta que el depósito de su tesis en el repositorio
     no lo inhabilita a realizar publicaciones derivadas con calidad de inédito; una obra derivada NO es la obra original.
    <br/>A fin de aplicar esta restricción, deberá adjuntar en este paso una nota de solicitud de embargo que justifique 
-   debidamente la solicitud (ver modelo <a href="http://sedici.unlp.edu.ar/blog/wp-content/uploads/2015/12/Modelo-nota-de-embargo.doc">Aqui</a>).
+   debidamente la solicitud (ver modelo <a href="http://blog.sedici.unlp.edu.ar/wp-content/uploads/sites/17/2018/09/Modelo-nota-de-embargo.doc">Aqui</a>).
 </message>
 
 <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head">Subir Fichero(s)</message>


### PR DESCRIPTION
Este PR agrega funcionalidad para evaluar los permisos que tiene el usuario actual (sobre la colección destino en la que se está realizando un envío) al momento de ejecutar un step durante el Submission (definidos en el **item-submission.xml**). Si la expresión definida es verdadera, entonces el usuario actual puede ejecutar el step.

Además se deshabilitó la carga de _archivos/bitstreams con embargo_ para los usuarios comunes de autoarchivo. Durante el autoarchivo, solo los revisores con permisos de ADMIN pueden ver el paso de carga de archivos con embargo.  

## Algunos casos de uso
### AUTOARCHIVO
1) Realizar un envío de autoarchivo común (aquel que solo tiene permiso de ADD sobre la colección de autoarchivo). El usuario de autoarchivo solo debe ver el step de "Carga de archivos" sin opciones de embargo (UploadStep).
2) Cuando lo toma para revisión un SEDICI-ADMIN, este sólo debe ver el step de "Carga de archivos con embargo" (UploadWithEmbargoStep).

Este es el caso específico para el que se creó este atributo. Para expresar esto se tuvo que configurar los siguientes pasos en el submission-process correspondiente a "AUTOARCHIVO":

```
<!--Step 3a will be to Upload the item-->
 <step id="sediciUploadItem" scope="!ADMIN"/>
 
 <!--Step 3b (Only For users with ADMINs permission) will be to Upload the item-->
 <step id="sediciUploadWithEmbargoItem" scope="ADMIN"/>
```

### PROBAR OTROS PERMISOS
1) Por ejemplo, configurar un step con `scope="REMOVE"` en el caso de autoarchivo. Solo debería poder ver este un SEDICI-ADMIN.
2) Por ejemplo, configurar un step con `scope="READ"`. Cualquier usuario tendría la posibilidad de ejecutar el step.

También se pueden **negar** los anteriores casos utilizando el símbolo **"!"**, por ejemplo: scope="!REMOVE". Probar estos casos también.

ACLARACIÓN: Tener en cuenta que solo se puede definir un único scope por step.