### PR TITLE
-#3370 Se ordenan las licencias CC mediante un orden lógico

### DIFF
--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/SediciAdministratorCCLicenseStep.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/SediciAdministratorCCLicenseStep.java
@@ -139,7 +139,6 @@ public class SediciAdministratorCCLicenseStep extends AbstractSubmissionStep
 			    String values=ConfigurationManager.getProperty(PropertiesFilename, "map.licenses");
 		        String[] valores=values.split(",");
 		        String[] valor;
-		        //TODO falta ver porqué no levanta bien el Label de la PublicDomain...
 		        for (String entrada : valores) {
 					valor=entrada.split(" = ");
 					Licencias.put(valor[0], valor[1]);

--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/SediciCCLicenseStep.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/SediciCCLicenseStep.java
@@ -141,10 +141,10 @@ public class SediciCCLicenseStep extends AbstractSubmissionStep
 		    select.addOption("", message("xmlui.Submission.submit.SediciCCLicenseStep.administrador.sinLicencia"));
 		    select.addOption("by", message("xmlui.Submission.submit.SediciCCLicenseStep.administrador.by"));
 		    select.addOption("by-nc", message("xmlui.Submission.submit.SediciCCLicenseStep.administrador.by-nc"));
-		    select.addOption("by-nc-nd", message("xmlui.Submission.submit.SediciCCLicenseStep.administrador.by-nc-nd"));
-		    select.addOption("by-nc-sa", message("xmlui.Submission.submit.SediciCCLicenseStep.administrador.by-nc-sa"));
 		    select.addOption("by-nd", message("xmlui.Submission.submit.SediciCCLicenseStep.administrador.by-nd"));
 		    select.addOption("by-sa", message("xmlui.Submission.submit.SediciCCLicenseStep.administrador.by-sa"));
+		    select.addOption("by-nc-nd", message("xmlui.Submission.submit.SediciCCLicenseStep.administrador.by-nc-nd"));
+		    select.addOption("by-nc-sa", message("xmlui.Submission.submit.SediciCCLicenseStep.administrador.by-nc-sa"));
 		   
 	        if (carga.length>0){
 		    	dato=carga[0].value;


### PR DESCRIPTION
Desde las menos restrictivas a las más restrictivas. Todas aquellas licencias que no coincidan con el patrón "http://creativecommons.org/licences/{...}" se ordenan alfabéticamente al final del listado de licencias.

Se utilizó un Comparator para determinar el orden. Primero se determina si las licencias comparadas son licencias que matcheen con el patrón indicado más arriba. Si es así, entonces se procede a descomponer la URL en sus componentes y se los va comparando. El orden de relevancia se da:
1. Primero se ordena crecientemente por el numero versión de la licencia (por ejemplo 2.5, 3.0, etc).
2. Para las licencias de la misma versión, se determina la cantidad de códigos como "by", "sa", "nd", etc, ordenando primero las que tienen menor cantidad de códigos.

Se corrigió este orden lógico de las licencias CC tanto para los steps `sediciCCLicense` y `sediciAdministratorCCLicense` definidos en el item-submission.xml.

Tuve que utilizar un TreeMap con un Comparator, ya que el HashMap (que se usaba anteriormente en el código) no garantiza el orden por definición (ver https://stackoverflow.com/a/10710241).

### Para probar de forma aislada
Se incluye una clase JAVA de prueba para probar el funcionamiento del Comparator implementado en la solución, si es que se quiere hacer algunas pruebas aisladas.
[CCLicenseComparatorByRegex.txt](https://github.com/sedici/DSpace/files/2397301/CCLicenseComparatorByRegex.txt)
Primero hay que cambiarle la extensión del .txt a .java (ya que Github no me dejaba subir un .java), luego compilarlo en la linea de comandos
```bash
javac CCLicenseComparatorByRegex.java
java CCLicenseComparatorByRegex
```
