### PR TITLE
 "#4814" Agrego el seteo por defecto del filterOperator en Discovery

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/DiscoveryUIUtils.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/DiscoveryUIUtils.java
@@ -45,8 +45,10 @@ public class DiscoveryUIUtils {
         for (int i = 0; i < filterTypes.size(); i++) {
             String filterType = filterTypes.get(i);
             String filterValue = filterValues.get(i);
-            String filterOperator = filterOperators.get(i);
-
+            String filterOperator = "equals";
+            if (filterOperators.size() > i) {
+            	filterOperator =  filterOperators.get(i);
+            }
             fqs.put("filtertype_" + i, new String[]{filterType});
             fqs.put("filter_relational_operator_" + i, new String[]{filterOperator});
             fqs.put("filter_" + i, new String[]{filterValue});
@@ -67,7 +69,10 @@ public class DiscoveryUIUtils {
 
             for (int i = 0; i < filterTypes.size(); i++) {
                 String filterType = filterTypes.get(i);
-                String filterOperator = filterOperators.get(i);
+                String filterOperator = "equals";
+                if (filterOperators.size() > i) {
+                	filterOperator =  filterOperators.get(i);
+                }
                 String filterValue = filterValues.get(i);
 
                 if(StringUtils.isNotBlank(filterValue)){

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SimpleSearch.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SimpleSearch.java
@@ -187,8 +187,10 @@ public class SimpleSearch extends AbstractSearch implements CacheableProcessingC
                 {
                     String filterType = filterTypes.get(i);
                     String filterValue = filterValues.get(i);
-                    String filterOperator = filterOperators.get(i);
-
+                    String filterOperator = "equals";
+                    if (filterOperators.size() > i) {
+                    	filterOperator =  filterOperators.get(i);
+                    }                    
                     if(StringUtils.isNotBlank(filterValue))
                     {
                         Row row = filtersTable.addRow("used-filters-" + i+1, Row.ROLE_DATA, "search-filter used-filter");


### PR DESCRIPTION
El problema surge debido a que googlebots hace request sin el parametro filter_relational_operator. Se ve que ese parametro, en dspace 1.8, no era utilizado y google indexo esa request y ahora cada vez que la tira, se quiere hacer un get en un array que no tiene nada (IndexOutOfBoundsException).

Se soluciona esto seteando el operador por defecto y preguntando si existe algun valor en el arreglo que se arma a partir del filter_relational_operator en el request.

Esto se produce en 3 lugares, la solución no es la mas elegante del mundo, pero debido a como esta modelado todo (y al ser dspac-xmlui), se decidió solucionarlo de esta manera.

