### PR TITLE
 "#4616" Se expone fecha de embargo en OAI

### DIFF
--- a/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
@@ -277,7 +277,7 @@ public class XOAI {
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         XmlOutputContext context = XmlOutputContext.emptyContext(out, Second);
-        retrieveMetadata(item).write(context);
+        retrieveMetadata(this.context, item).write(context);
         context.getWriter().flush();
         context.getWriter().close();
         doc.addField("item.compile", out.toString());
@@ -465,7 +465,7 @@ public class XOAI {
             while (iterator.hasNext()) {
                 Item item = iterator.next();
                 if (verbose) System.out.println("Compiling item with handle: " + item.getHandle());
-                xoaiItemCacheService.put(item, retrieveMetadata(item));
+                xoaiItemCacheService.put(item, retrieveMetadata(context, item));
                 context.clearCache();
             }
 

--- a/dspace-oai/src/main/java/org/dspace/xoai/services/impl/xoai/DSpaceItemDatabaseRepository.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/impl/xoai/DSpaceItemDatabaseRepository.java
@@ -68,13 +68,13 @@ public class DSpaceItemDatabaseRepository extends DSpaceItemRepository
         this.useCache = configurationService.getBooleanProperty("oai", "cache.enabled", true);
     }
     
-    private Metadata getMetadata (org.dspace.content.Item item) throws IOException {
+    private Metadata getMetadata (org.dspace.content.Item item) throws IOException, ContextServiceException {
         if (this.useCache) {
             if (!cacheService.hasCache(item))
-                cacheService.put(item, ItemUtils.retrieveMetadata(item));
+                cacheService.put(item, ItemUtils.retrieveMetadata(context.getContext(), item));
             
             return cacheService.get(item);
-        } else return ItemUtils.retrieveMetadata(item);
+        } else return ItemUtils.retrieveMetadata(context.getContext(), item);
     }
 
     private List<ReferenceSet> getSets(org.dspace.content.Item item)

--- a/dspace/config/crosswalks/oai/metadataFormats/oai_dc.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/oai_dc.xsl
@@ -214,14 +214,32 @@
 				<dc:type><xsl:value-of select="." /></dc:type>
 			</xsl:for-each>
 
-			<!-- AccessType de OpenAire opcional -->
-			<!-- driver.rights.accessRights = rights - for SNRD and DRIVER-->	
-			<xsl:for-each select="doc:metadata/doc:element[@name='driver']/doc:element[@name='rights']/doc:element[@name='accessRights']/doc:element/doc:field[@name='value']">
-				<dc:rights><xsl:value-of select="." /></dc:rights>
-			</xsl:for-each>
-			
-			
 			<!--sedici.rights.* = rights -->
+			<xsl:variable name="bitstreams" select="doc:metadata/doc:element[@name='bundles']/doc:element[@name='bundle'][./doc:field/text()='ORIGINAL']/doc:element[@name='bitstreams']/doc:element[@name='bitstream']"/>
+			<xsl:variable name="embargoed" select="$bitstreams/doc:field[@name='embargo']"/>
+
+			<xsl:choose>
+				<xsl:when test="count($bitstreams) = 0 or count($embargoed[text() = 'forever']) = count($bitstreams) ">
+					<dc:rights>info:eu-repo/semantics/closedAccess</dc:rights>
+				</xsl:when>
+				<xsl:when test="count($embargoed) = 0">
+					<dc:rights>info:eu-repo/semantics/openAccess</dc:rights>
+				</xsl:when>
+				<xsl:when test="count($embargoed[text() = 'forever']) &gt; 0">
+					<dc:rights>info:eu-repo/semantics/restrictedAccess</dc:rights>
+				</xsl:when>
+				<xsl:otherwise>
+<!-- 			es un embargoedAccess si o si -->
+					<xsl:for-each select="$embargoed">
+						<xsl:sort select="text()" />
+						<xsl:if test="position() = 1">
+							<dc:date><xsl:value-of select="concat('info:eu-repo/date/embargoEnd/',text())"/></dc:date>
+							<dc:rigths>info:eu-repo/semantics/embargoedAccess</dc:rigths>
+						</xsl:if>
+					</xsl:for-each>
+				</xsl:otherwise>
+			</xsl:choose>
+
 			<xsl:for-each select="doc:metadata/doc:element[@name='sedici']/doc:element[@name='rights']/doc:element[@name='uri']/doc:element/doc:field[@name='value']">
 				<dc:rights><xsl:value-of select="." /></dc:rights>
 			</xsl:for-each>


### PR DESCRIPTION
El campo dc:rights se infiere en base a la accesibilidad de los bitstreams siguiendo el siguiente criterio:

 **info:eu-repo/semantics/closedAccess:**

 - no tiene bitstreams.
 - todos sus bitstreams tienen embargo forever.

 **info:eu-repo/semantics/openAccess**
 - no tiene bitstreams con embargo.

 **info:eu-repo/semantics/restrictedAccess**
 - tiene al menos un embargo forever (pero no todos).

 **info:eu-repo/semantics/_UnaFecha_**
 - tiene al menos un embargo que es una fecha.

Para eso se tuvo que modificar el mensaje [retrieveMetadata (Context context, Item item)](https://github.com/sedici/DSpace/blob/9203db5ad4e73c5d625aec4d7e75083d98d4f07d/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java#L71) 

En este mensaje se agregan los metadatos que se procesaran en los filters y transformer. [En esta línea](https://github.com/sedici/DSpace/blob/9203db5ad4e73c5d625aec4d7e75083d98d4f07d/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java#L233) tuve que pedir las polices de los bitstreams, es por eso que necesiée modificar el mensaje retriveMetadata para que reciba el context y por ende, las tres veces donde se invoca dicho mensaje (para que también pasen el contexto) que sería [acá](https://github.com/sedici/DSpace/blob/9203db5ad4e73c5d625aec4d7e75083d98d4f07d/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java#L280), [acá](https://github.com/sedici/DSpace/blob/9203db5ad4e73c5d625aec4d7e75083d98d4f07d/dspace-oai/src/main/java/org/dspace/xoai/services/impl/xoai/DSpaceItemDatabaseRepository.java#L74) y [acá](https://github.com/sedici/DSpace/blob/9203db5ad4e73c5d625aec4d7e75083d98d4f07d/dspace-oai/src/main/java/org/dspace/xoai/services/impl/xoai/DSpaceItemDatabaseRepository.java#L77)
