### PR TITLE
-#4769 Se corrigió el manejo de errores desde el sitemap

### DIFF
--- a/dspace/modules/xmlui/src/main/webapp/exception2html.xslt
+++ b/dspace/modules/xmlui/src/main/webapp/exception2html.xslt
@@ -11,14 +11,16 @@
 <xsl:stylesheet version="1.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:ex="http://apache.org/cocoon/exception/1.0"
-                xmlns:i18n="http://apache.org/cocoon/i18n/2.1">
+                xmlns:i18n="http://apache.org/cocoon/i18n/2.1"
+                xmlns:date="http://exslt.org/dates-and-times" 
+                extension-element-prefixes="date">
 
   <xsl:param name="realPath"/>
   <xsl:param name="errorKind">internalError</xsl:param>
   <xsl:param name="contextPath">/</xsl:param>
   <xsl:param name="printDebug">false</xsl:param>
   <xsl:param name="requestQueryString"></xsl:param>
-  <xsl:param name="themePath"></xsl:param>
+  <xsl:param name="themePath">Sedici2</xsl:param>
 <xsl:template match="/">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
@@ -84,7 +86,7 @@
 	<div id="ds-main" xmlns="http://di.tamu.edu/DRI/1.0/"
 		xmlns:i18n="http://apache.org/cocoon/i18n/2.1">
 		<div id="ds-header-wrapper">
-          	<div id="ds-header" class="clearfix">
+          	<div id="ds-header" class="clearfix" style="height: 3em;">
             	<a id="ds-header-logo-link">
                     <xsl:attribute name="href">
                         <xsl:value-of select="concat($contextPath,'/')"/>
@@ -162,7 +164,7 @@
 		                    <a href="http://prebi.unlp.edu.ar/" target="_blank">PREBI</a>
 		                    <span> - </span>
 		                    <a href="http://sedici.unlp.edu.ar/" target="_blank">SEDICI</a>
-		                    &#xA9; 2003-2013
+		                    &#xA9; 2003-<xsl:value-of select="date:year()"/>
 		                    <br/>
 		                    <a href="http://www.unlp.edu.ar" target="_blank">Universidad Nacional de La Plata</a>
 	                    </strong>
@@ -173,11 +175,11 @@
 	            </div>
 	            <div class="column" id="footercol3">
 	                <div class="datos_sedici">
-	                    Calle 49 y 115 s/n 1er piso - Edificio ex Liceo
-	                    <br/>
-	                    La Plata, Buenos Aires (C.P. 1900)
-	                    <br/>
-	                    Tel 0221 423 6696/6677 (int. 141)
+	                    <i18n:text>xmlui.dri2xhtml.structural.footer.developers.address</i18n:text>
+                        <br/>
+                        <i18n:text>xmlui.dri2xhtml.structural.footer.developers.district</i18n:text>
+                        <br/>
+                        <i18n:text>xmlui.dri2xhtml.structural.footer.developers.contact-phone</i18n:text>
 	                </div>
                     <div class="footer-icon">
                         <a title="Como llegar a SEDICI">

--- a/dspace/modules/xmlui/src/main/webapp/sitemap.xmap
+++ b/dspace/modules/xmlui/src/main/webapp/sitemap.xmap
@@ -178,7 +178,6 @@
                                 <exception name="invalid-continuation" class="org.apache.cocoon.components.flow.InvalidContinuationException"/>
                                 <exception name="bad-request" class="org.dspace.app.xmlui.utils.BadRequestException"/>
                                 <exception name="authorize-exception" class="org.dspace.authorize.AuthorizeException"/>
-                                <exception name="file-not-found-exception" class="java.io.FileNotFoundException"/>
                                 <!-- The statement below tells the selector to unroll as much exceptions as possible -->
                                 <exception class="java.lang.Throwable" unroll="true"/>
                         </map:selector>
@@ -772,23 +771,6 @@
 			                        <map:serialize type="xhtml" status-code="404" />
 			                    </map:when>
 			                    
-			                    <map:when test="file-not-found-exception">
-			                    <!--  Error 404/Resource not found -->
-			                        <map:generate type="exception"/>
-			                        <map:transform src="exception2html.xslt">
-			                            <map:parameter name="contextPath" value="{request:contextPath}" />
-			                            <map:parameter name="printDebug" value="{xmlui_debug}" />
-			                            <map:parameter name="errorKind" value="resourceNotFound" />
-			                            <map:parameter name="requestQueryString" value="{request:queryString}"/>
-			                        </map:transform>
-			                        <map:act type="locale">
-			                            <map:transform type="i18n">
-			                                <map:parameter name="locale" value="{locale}" />
-			                            </map:transform>
-			                        </map:act>
-			                        <map:serialize type="xhtml" status-code="404" />
-			                    </map:when>
-
                                 <map:otherwise>
                                         <map:generate type="exception"/>
                                         <map:act type="ExceptionAction" />

--- a/dspace/modules/xmlui/src/main/webapp/sitemap.xmap
+++ b/dspace/modules/xmlui/src/main/webapp/sitemap.xmap
@@ -177,6 +177,8 @@
                                 <exception name="not-found" class="org.apache.cocoon.ResourceNotFoundException"/>
                                 <exception name="invalid-continuation" class="org.apache.cocoon.components.flow.InvalidContinuationException"/>
                                 <exception name="bad-request" class="org.dspace.app.xmlui.utils.BadRequestException"/>
+                                <exception name="authorize-exception" class="org.dspace.authorize.AuthorizeException"/>
+                                <exception name="file-not-found-exception" class="java.io.FileNotFoundException"/>
                                 <!-- The statement below tells the selector to unroll as much exceptions as possible -->
                                 <exception class="java.lang.Throwable" unroll="true"/>
                         </map:selector>
@@ -209,6 +211,7 @@
                         <map:action name="DSpacePropertyFileReader" src="org.dspace.app.xmlui.cocoon.DSpacePropertyFileReader" />
                         <map:action name="PropertyFileReader" src="org.dspace.app.xmlui.cocoon.PropertyFileReader" />
                         <map:action name="DspacePropertyAction" src="ar.edu.unlp.sedici.xmlui.actions.DpsacePropertyAction" />
+                        <map:action name="ExceptionAction" src="ar.edu.unlp.sedici.aspect.redirect.ExceptionAction" />
                 </map:actions>
                 <map:pipes default="caching">
                         <map:pipe name="noncaching" src="org.apache.cocoon.components.pipeline.impl.NonCachingProcessingPipeline">
@@ -710,7 +713,9 @@
                                         <map:generate type="exception"/>
                                         <map:transform src="exception2html.xslt">
                                                 <map:parameter name="contextPath" value="{request:contextPath}"/>
-                                                <map:parameter name="pageTitle" value="Bad request"/>
+                                                <map:parameter name="printDebug" value="{xmlui_debug}" />
+                                                <map:parameter name="errorKind" value="badRequest" />
+                                                <map:parameter name="requestQueryString" value="{request:queryString}"/>
                                         </map:transform>
                                         <map:act type="locale">
                                             <map:transform type="i18n">
@@ -722,12 +727,11 @@
 
                                 <map:when test="not-found">
                                         <map:generate type="exception"/>
-                                        <map:transform src="themes/{session-attr:theme}exception2html.xslt">
+                                        <map:transform src="exception2html.xslt">
 				   							<map:parameter name="contextPath" value="{request:contextPath}" />
 											<map:parameter name="printDebug" value="{xmlui_debug}" />
 											<map:parameter name="errorKind" value="resourceNotFound" />
 											<map:parameter name="requestQueryString" value="{request:queryString}"/>
-											<map:parameter name="themePath" value="{session-attr:theme}" />
 										</map:transform>
                                         <map:act type="locale">
                                             <map:transform type="i18n">
@@ -741,7 +745,8 @@
                                         <map:generate type="exception"/>
                                         <map:transform src="exception2html.xslt">
                                                 <map:parameter name="contextPath" value="{request:contextPath}"/>
-                                                <map:parameter name="pageTitle" value="Your Session has Expired"/>
+                                                <map:parameter name="printDebug" value="{xmlui_debug}" />
+                                                <map:parameter name="errorKind" value="invalidContinuation" />
                                         </map:transform>
                                         <map:act type="locale">
                                             <map:transform type="i18n">
@@ -750,15 +755,48 @@
                                         </map:act>
                                         <map:serialize type="xhtml" status-code="404"/>
                                 </map:when>
+                                
+                                <map:when test="authorize-exception">
+                                    <map:generate type="exception"/>
+			                        <map:transform src="exception2html.xslt">
+			                            <map:parameter name="contextPath" value="{request:contextPath}" />
+			                            <map:parameter name="printDebug" value="{xmlui_debug}" />
+			                            <map:parameter name="errorKind" value="notAuthorize" />
+			                            <map:parameter name="requestQueryString" value="{request:queryString}"/>
+			                        </map:transform>
+			                        <map:act type="locale">
+			                            <map:transform type="i18n">
+			                                <map:parameter name="locale" value="{locale}" />
+			                            </map:transform>
+			                        </map:act>
+			                        <map:serialize type="xhtml" status-code="404" />
+			                    </map:when>
+			                    
+			                    <map:when test="file-not-found-exception">
+			                    <!--  Error 404/Resource not found -->
+			                        <map:generate type="exception"/>
+			                        <map:transform src="exception2html.xslt">
+			                            <map:parameter name="contextPath" value="{request:contextPath}" />
+			                            <map:parameter name="printDebug" value="{xmlui_debug}" />
+			                            <map:parameter name="errorKind" value="resourceNotFound" />
+			                            <map:parameter name="requestQueryString" value="{request:queryString}"/>
+			                        </map:transform>
+			                        <map:act type="locale">
+			                            <map:transform type="i18n">
+			                                <map:parameter name="locale" value="{locale}" />
+			                            </map:transform>
+			                        </map:act>
+			                        <map:serialize type="xhtml" status-code="404" />
+			                    </map:when>
 
                                 <map:otherwise>
                                         <map:generate type="exception"/>
-                                        <map:transform src="themes/{session-attr:theme}exception2html.xslt">
+                                        <map:act type="ExceptionAction" />
+                                        <map:transform src="exception2html.xslt">
 				   							<map:parameter name="contextPath" value="{request:contextPath}" />
 											<map:parameter name="printDebug" value="{xmlui_debug}" />
 											<map:parameter name="errorKind" value="internalError" />
 											<map:parameter name="requestQueryString" value="{request:queryString}"/>
-											<map:parameter name="themePath" value="{session-attr:theme}" />
                                         </map:transform>
                                         <map:act type="locale">
                                             <map:transform type="i18n">

--- a/dspace/modules/xmlui/src/main/webapp/sitemap.xmap
+++ b/dspace/modules/xmlui/src/main/webapp/sitemap.xmap
@@ -184,10 +184,11 @@
                         <map:selector name="AuthenticatedSelector" src="org.dspace.app.xmlui.aspect.general.AuthenticatedSelector"/>
                 </map:selectors>
                 <map:readers default="resource">
-                    <map:reader name="resource" src="org.apache.cocoon.reading.ResourceReader"
+                    <map:reader name="resource" src="org.dspace.app.xmlui.cocoon.SafeResourceReader"
                             logger="sitemap.reader.resource" pool-max="32">
                             <expires>3600000</expires> <!-- 1000 * 60 * 60 = 3600000 = One hour -->
                     </map:reader>
+                    <map:reader name="ThemeResourceReader" src="org.dspace.app.xmlui.cocoon.ThemeResourceReader"/>
                     <map:reader name="BitstreamReader" src="org.dspace.app.xmlui.cocoon.BitstreamReader"/>
                     <map:reader name="ExportReader" src="org.dspace.app.xmlui.cocoon.ItemExportDownloadReader"/>
                     <map:reader name="MetadataExportReader" src="org.dspace.app.xmlui.cocoon.MetadataExportReader"/>
@@ -621,10 +622,18 @@
                             </map:read>
                     </map:match>
 
+                    <!-- Redirect / block for DS-3094 (security issue) for custom themes -->
+                    <!-- This ensures any custom themes are not affected by DS-3094 by redirecting
+                         vulnerable URL paths to /error (which returns a 404 File Not Found).
+                         Custom themes may still be affected by this issue, if they have not
+                         been updated to use ThemeResourceReader in all <map:read> settings. -->
+                    <map:match pattern="themes/**:**">
+                        <map:redirect-to uri="{request:contextPath}/error" permanent="yes"/>
+                    </map:match>
 
                     <!-- handle common theme resources, such as dri2xhtml -->
                     <map:match pattern="themes/*">
-                        <map:read src="themes/{1}"/>
+                        <map:read type="ThemeResourceReader" src="themes/{1}"/>
                     </map:match>
 
                     <!-- handle theme specific resources static or dynamic -->
@@ -645,6 +654,14 @@
                         This will allow your globally static HTML docs to load static CSS or images. -->
                     <map:match pattern="static/*/**">
                         <map:read src="static/{1}/{2}"/>
+                    </map:match>
+
+                    <!-- DSpace does not have any paths beginning with numbers (0-9). If one is accessed,
+                         assume that it is an identifier & redirect it. This also avoids an internal
+                         error, where the XMLUI AspectMatcher wrongly assumes numbers at beginning
+                         of path are direct references to individual Aspects in the aspect chain.-->
+                    <map:match type="regexp" pattern="(^[0-9]+\/?.*$)">
+                        <map:redirect-to uri="{request:contextPath}/handle/{1}" permanent="yes"/>
                     </map:match>
 
                 </map:pipeline>

--- a/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/sitemap.xmap
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/sitemap.xmap
@@ -214,8 +214,7 @@
 			</map:match>
 		</map:pipeline>
 
-
-		<map:handle-errors>
+<!--		<map:handle-errors>
 			<map:act type="DspacePropertyAction" >
 				<map:parameter name="module" value="sedici-dspace" />
 				<map:parameter name="property" value="xmlui.debug" />
@@ -226,7 +225,6 @@
 				
 				<map:select type="exceptionSedici">
 					<map:when test="bad-request">
-						<!--  Error 400/Bad Request -->
 						<map:transform src="exception2html.xslt">
 							<map:parameter name="contextPath" value="{request:contextPath}" />
 							<map:parameter name="printDebug" value="{xmlui_debug}" />
@@ -243,7 +241,6 @@
 					</map:when>
 					
 					<map:when test="not-found">
-						<!--  Error 404/Resource not found -->
 						<map:transform src="exception2html.xslt">
 							<map:parameter name="contextPath" value="{request:contextPath}" />
 							<map:parameter name="printDebug" value="{xmlui_debug}" />
@@ -260,7 +257,6 @@
 					</map:when>
 					
 					<map:when test="invalid-continuation">
-						<!--  Error 404/invalidContinuation -->
 						<map:transform src="exception2html.xslt">
 							<map:parameter name="contextPath" value="{request:contextPath}" />
 							<map:parameter name="printDebug" value="{xmlui_debug}" />
@@ -292,7 +288,6 @@
 					</map:when>
 					
 					<map:when test="file-not-found-exception">
-					<!--  Error 404/Resource not found -->
 						<map:transform src="exception2html.xslt">
 							<map:parameter name="contextPath" value="{request:contextPath}" />
 							<map:parameter name="printDebug" value="{xmlui_debug}" />
@@ -308,7 +303,6 @@
 						<map:serialize type="xhtml" status-code="404" />
 	                </map:when>
 					<map:otherwise>
-						<!--  Error 5xx -->
 						<map:act type="ExceptionAction" />
 						
 						<map:transform src="exception2html.xslt">
@@ -328,6 +322,6 @@
 				</map:select>
 
 			</map:act>
-		</map:handle-errors>
+		</map:handle-errors>-->
 	</map:pipelines>
 </map:sitemap>


### PR DESCRIPTION
Ver descripción y problemas completos en ticket numero 4769 del trac.

Se configuró ruta a transformer xslt ya que la propiedad session-attr:theme no estaba devolviendo nada.

Se subió el transformer exception2html.xslt arriba de todo.
Se actualizó el código de transformer para incluir algunos cambios recientes propios de la vista.

Se deshabilitó el manejo de errores desde el themes/Sedici2/sitemap.xmap ya que lo maneja el sitemap de arriba.