### PR TITLE
 "#4800" Quito acentos al momento de normalizar texto de búsqueda

### DIFF
--- a/dspace-api/src/main/java/org/dspace/text/filter/DecomposeDiactritics.java
+++ b/dspace-api/src/main/java/org/dspace/text/filter/DecomposeDiactritics.java
@@ -18,11 +18,11 @@ public class DecomposeDiactritics implements TextFilter
 {
     public String filter(String str)
     {
-        return Normalizer.normalize(str, Normalizer.NFD);
+        return Normalizer.normalize(str, Normalizer.NFD).replaceAll("[\\p{InCombiningDiacriticalMarks}]", "");
     }
 
     public String filter(String str, String lang)
     {
-        return Normalizer.normalize(str, Normalizer.NFD);
+        return Normalizer.normalize(str, Normalizer.NFD).replaceAll("[\\p{InCombiningDiacriticalMarks}]", "");
     }
 }

--- a/dspace/solr/search/conf/schema.xml
+++ b/dspace/solr/search/conf/schema.xml
@@ -453,7 +453,7 @@
         <analyzer>
             <!--Treats the entire field as a single token, regardless of its content-->
             <tokenizer class="solr.KeywordTokenizerFactory"/>
-			<filter class="solr.ASCIIFoldingFilterFactory"/>
+
             <!--<filter class="solr.LowerCaseFilterFactory" />-->
             <filter class="solr.TrimFilterFactory" />
         </analyzer>


### PR DESCRIPTION
Ahora el facet de browse de autores incluye las tildes en los nombres y en la búsqueda se normaliza el texto ingresado normalmente. Ahora es lo mismo buscar por el string "Sánchez" que por "Sanchez"

Para comprobar que es indistinta la búsqueda por "Sánchez" o "Sanchez" se puede probar el reindexando los handles:

- 10915/26117 (Autor: Sánchez, Juliana Patricia )
- 10915/19467 (Autor: Sanchez, Valeria)

Como en DSpace 5 no está la opción de reindexar un item por handle (si esta en dspace 6, haciendo _./dspace index-discovery -fi_) una opción es ir y modificar los metadatos del ítem (o ir a "Editar este ítem" -> "Metadatos del ítem", y sin realizar ningún cambio, hacer click en "Modificar"... con eso alcanza)

El resultado de la búsqueda debería retornar los dos autores y no uno. Hoy en día este problema no esta presente ya que se indexan los autores sin tildes