### PR TITLE
-#4933 Improve behaviour for mark and deletion of bots

### DIFF
--- a/dspace-api/src/main/java/org/dspace/statistics/SolrLogger.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/SolrLogger.java
@@ -799,7 +799,7 @@ public class SolrLogger
                 log.error("ERROR when processing pattern for solr field \"ip\", "
                         + "with pattern value: \"" + ip + "\".\n" + e.getMessage(), e);
             } catch (RemoteSolrException e) {
-                log.fatal("ERROR when processing pattern for solr field \"ip\", "
+                log.error("ERROR when processing pattern for solr field \"ip\", "
                         + "with pattern value: \"" + ip + "\".\n" + e.getMessage(), e);
                 //Stop execution re-throwing runtime exception...
                 throw e;
@@ -866,7 +866,7 @@ public class SolrLogger
                 log.error("ERROR when processing pattern for solr field \"" + solrFieldName + "\", "
                         + "with pattern value: \"" + pattern + "\".\n" + e.getMessage(), e);
             } catch (RemoteSolrException e) {
-                log.fatal("ERROR when processing pattern for solr field \"" + solrFieldName + "\", "
+                log.error("ERROR when processing pattern for solr field \"" + solrFieldName + "\", "
                         + "with pattern value: \"" + pattern + "\".\n" + e.getMessage(), e);
               //Stop execution re-throwing runtime exception...
                 throw e;
@@ -946,7 +946,7 @@ public class SolrLogger
             log.error("ERROR when deleting records for delete query \"" + query + "\".\n" 
                          + e.getMessage(), e);
         } catch (RemoteSolrException e) {
-            log.fatal("ERROR when deleting records for delete query \"" + query + "\".\n" 
+            log.error("ERROR when deleting records for delete query \"" + query + "\".\n" 
                     + e.getMessage(), e);
             //Stop execution re-throwing runtime exception...
             throw e;

--- a/dspace-api/src/main/java/org/dspace/statistics/SolrLogger.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/SolrLogger.java
@@ -715,6 +715,11 @@ public class SolrLogger
 
     public static class ResultProcessor
     {
+        /**
+         * If true, every time when process a list of documents using {@link ResultProcessor#process(List)} a 
+         * {@link HttpSolrServer#commit()} will be executed.
+         */
+        private boolean commitAtEveryProcess = false;
 
         public void execute(String query) throws SolrServerException, IOException {
             Map<String, String> params = new HashMap<String, String>();
@@ -735,11 +740,19 @@ public class SolrLogger
             // Run over the rest
             for (int i = maxDocumetsPerProcess; i < numbFound; i += maxDocumetsPerProcess)
             {
-                params.put("start", String.valueOf(i));
+                if(commitAtEveryProcess) {
+                    commit();
+                } else {
+                    //If not use commit at each set of changes, pagination must be used To avoid solr version conflict when update a doc.
+                    //See "Optimistic concurrency control" in Solr.
+                    params.put("start", String.valueOf(i));
+                }
                 solrParams = new MapSolrParams(params);
                 response = solr.query(solrParams);
                 process(response.getResults());
             }
+            //Commit lastest changes
+            commit();
 
         }
 
@@ -755,6 +768,21 @@ public class SolrLogger
             for(SolrDocument doc : docs){
                 process(doc);
             }
+        }
+        
+        /**
+         * Set the processor to always make a commit of the changes to Solr when call {@link ResultProcessor#process(List)}.
+         */
+        public void alwaysCommitAtProcess() {
+            commitAtEveryProcess = true;
+        }
+        
+        /**
+         * The processor will not manage the commits of changes, it will be delegated to the default Solr configuration.
+         * Is the oposite of {@link ResultProcessor#alwaysCommitAtProcess()}.
+         */
+        public void onlyAutoCommit() {
+            commitAtEveryProcess = false;
         }
 
         /**
@@ -826,29 +854,33 @@ public class SolrLogger
     private static void markRobotsBy(String solrFieldName, Set<String> listOfPatterns){
         listOfPatterns = (listOfPatterns == null)? new HashSet<String>(): listOfPatterns;
         int counter = 0;
-        if(solrFieldName == null && solrFieldName.isEmpty()) {
+        if(solrFieldName == null || solrFieldName.isEmpty()) {
             log.error("Invalid solr field name passed when marking bots: is null or empty.");
             return;
         }
+        
+        /* Result Process to alter record to be identified as a bot */
+        ResultProcessor processor = new ResultProcessor(){
+            @Override
+            public void process(SolrDocument doc) throws IOException, SolrServerException {
+                doc.removeFields("isBot");
+                doc.addField("isBot", true);
+                SolrInputDocument newInput = ClientUtils.toSolrInputDocument(doc);
+                solr.add(newInput);
+            }
+        };
+        
+        processor.alwaysCommitAtProcess();
         
         for(String pattern : listOfPatterns)
         {
             log.info("(" + counter + "/" + listOfPatterns.size() + ") Processing pattern for solr field \"" + solrFieldName + "\", pattern value: \"" + pattern + "\"");
             try {
-                /* Result Process to alter record to be identified as a bot */
-                ResultProcessor processor = new ResultProcessor(){
-                    @Override
-                    public void process(SolrDocument doc) throws IOException, SolrServerException {
-                        doc.removeFields("isBot");
-                        doc.addField("isBot", true);
-                        SolrInputDocument newInput = ClientUtils.toSolrInputDocument(doc);
-                        solr.add(newInput);
-                    }
-                };
                 /* query for the specified spider pattern, exclude results previously set as bots. */
                 processor.execute(solrFieldName + ":/" + buildSolrRegex(pattern) + "/ AND -isBot:true");
                 
-                solr.commit();
+                /** The processor is configured to make at every doc processing... See ResultProcessor.alwaysCommitAtProcess() */
+                //solr.commit();
             } catch (Exception e) {
                 log.error(e.getMessage(),e);
             }
@@ -916,29 +948,34 @@ public class SolrLogger
     }
     
     /**
+     * Delete Solr statistics records that matches the passed query.
+     * @param query
+     */
+    private static void deleteBy(String query)
+    {
+        try {
+            solr.deleteByQuery(query);
+        } catch (SolrServerException | IOException e) {
+            log.error(e.getMessage(),e);
+        }
+    }
+    
+    /**
      * Delete robots by multiple criteria: IP, User Agent, and Domain.
      */
     public static void deleteRobots()
     {
         log.info("Delete robots by IP starting now...");
         for(String ip : SpiderDetector.getSpiderIpAddresses()){
-            deleteIP(ip);
+            deleteBy("ip:" + ip + "*");
         }
         log.info("Delete robots by User Agent starting now...");
         for(String agent : SpiderDetector.getSpiderAgents()) {
-            try {
-                solr.deleteByQuery("userAgent:/"+ buildSolrRegex(agent) + "/");
-            } catch (Exception e) {
-                 log.error("[pattern '" + agent + "']" + e.getMessage(),e);
-            }
+            deleteBy("userAgent:/" + buildSolrRegex(agent) + "/");
         }
         log.info("Delete robots by Domain starting now...");
         for(String domain : SpiderDetector.getSpiderDomains()) {
-            try {
-                solr.deleteByQuery("dns:/"+ buildSolrRegex(domain) + "/");
-            } catch (Exception e) {
-                log.error("[pattern '" + domain + "']" + e.getMessage(),e);
-            }
+            deleteBy("dns:/" + buildSolrRegex(domain) + "/");
         }
     }
 

--- a/dspace-api/src/main/java/org/dspace/statistics/SolrLogger.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/SolrLogger.java
@@ -715,15 +715,10 @@ public class SolrLogger
 
     public static class ResultProcessor
     {
-        /**
-         * If true, every time when process a list of documents using {@link ResultProcessor#process(List)} a 
-         * {@link HttpSolrServer#commit()} will be executed.
-         */
-        private boolean commitAtEveryProcess = false;
 
         public void execute(String query) throws SolrServerException, IOException {
             Map<String, String> params = new HashMap<String, String>();
-            int maxDocumetsPerProcess= ConfigurationManager.getIntProperty("solr-statistics", "spiders.resultProcessor.maxDocuments",10);
+            int maxDocumetsPerProcess= ConfigurationManager.getIntProperty("solr-statistics", "spiderDetector.batchUpdateSize",10);
             params.put("q", query);
             params.put("rows", String.valueOf(maxDocumetsPerProcess));
             if(0 < statisticYearCores.size()){
@@ -740,13 +735,8 @@ public class SolrLogger
             // Run over the rest
             for (int i = maxDocumetsPerProcess; i < numbFound; i += maxDocumetsPerProcess)
             {
-                if(commitAtEveryProcess) {
-                    commit();
-                } else {
-                    //If not use commit at each set of changes, pagination must be used To avoid solr version conflict when update a doc.
-                    //See "Optimistic concurrency control" in Solr.
-                    params.put("start", String.valueOf(i));
-                }
+                //force solr commit to avoid trigering autocommits inside solr
+                commit();
                 solrParams = new MapSolrParams(params);
                 response = solr.query(solrParams);
                 process(response.getResults());
@@ -770,21 +760,6 @@ public class SolrLogger
             }
         }
         
-        /**
-         * Set the processor to always make a commit of the changes to Solr when call {@link ResultProcessor#process(List)}.
-         */
-        public void alwaysCommitAtProcess() {
-            commitAtEveryProcess = true;
-        }
-        
-        /**
-         * The processor will not manage the commits of changes, it will be delegated to the default Solr configuration.
-         * Is the oposite of {@link ResultProcessor#alwaysCommitAtProcess()}.
-         */
-        public void onlyAutoCommit() {
-            commitAtEveryProcess = false;
-        }
-
         /**
          * Override to manage individual documents
          * @param doc
@@ -815,11 +790,13 @@ public class SolrLogger
 
                 /* query for ip, exclude results previously set as bots. */
                 processor.execute("ip:"+ip+ "* AND -isBot:true");
-
-                solr.commit();
+                
+                //Disable external commit, because the ResultProcessor always makes a commit at each processing batch...
+                //solr.commit();
 
             } catch (Exception e) {
-                log.error(e.getMessage(),e);
+                log.error("ERROR when processing pattern for solr field \"ip\", "
+                        + "with pattern value: \"" + ip + "\".\n" + e.getMessage(), e);
             }
 
 
@@ -870,8 +847,6 @@ public class SolrLogger
             }
         };
         
-        processor.alwaysCommitAtProcess();
-        
         for(String pattern : listOfPatterns)
         {
             log.info("(" + counter + "/" + listOfPatterns.size() + ") Processing pattern for solr field \"" + solrFieldName + "\", pattern value: \"" + pattern + "\"");
@@ -882,7 +857,8 @@ public class SolrLogger
                 /** The processor is configured to make at every doc processing... See ResultProcessor.alwaysCommitAtProcess() */
                 //solr.commit();
             } catch (Exception e) {
-                log.error(e.getMessage(),e);
+                log.error("ERROR when processing pattern for solr field \"" + solrFieldName + "\", "
+                        + "with pattern value: \"" + pattern + "\".\n" + e.getMessage(), e);
             }
             counter++;
         }
@@ -956,7 +932,8 @@ public class SolrLogger
         try {
             solr.deleteByQuery(query);
         } catch (SolrServerException | IOException e) {
-            log.error(e.getMessage(),e);
+            log.error("ERROR when deleting records for delete query \"" + query + "\".\n" 
+                         + e.getMessage(), e);
         }
     }
     

--- a/dspace-api/src/main/java/org/dspace/statistics/util/StatisticsClient.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/util/StatisticsClient.java
@@ -57,7 +57,7 @@ public class StatisticsClient
 
         options.addOption("m", "mark-spiders", false, "Update isBot Flag in Solr");
         options.addOption("f", "delete-spiders-by-flag", false, "Delete Spiders in Solr By isBot Flag");
-        options.addOption("i", "delete-spiders-by-ip", false, "Delete Spiders in Solr By IP Address");
+        options.addOption("i", "delete-spiders", false, "Delete Spiders in Solr By Multiple Criteria: IP Address, User Agent, and Domain (from Reverse DNS Lookup)");
         options.addOption("o", "optimize", false, "Run maintenance on the SOLR index");
         options.addOption("b", "reindex-bitstreams", false, "Reindex the bitstreams to ensure we have the bundle name");
         options.addOption("e", "export", false, "Export SOLR view statistics data to usage-statistics-intermediate-format");
@@ -79,7 +79,7 @@ public class StatisticsClient
         }
         else if (line.hasOption('m'))
         {
-            SolrLogger.markRobotsByIP();
+            SolrLogger.markRobots();
         }
         else if(line.hasOption('f'))
         {
@@ -87,7 +87,7 @@ public class StatisticsClient
         }
         else if(line.hasOption('i'))
         {
-            SolrLogger.deleteRobotsByIP();
+            SolrLogger.deleteRobots();
         }
         else if(line.hasOption('o'))
         {

--- a/dspace/config/modules/solr-statistics.cfg
+++ b/dspace/config/modules/solr-statistics.cfg
@@ -31,3 +31,8 @@ spiderips.urls = http://iplists.com/google.txt, \
                  http://iplists.com/excite.txt, \
                  http://iplists.com/misc.txt, \
                  http://iplists.com/non_engines.txt
+                 
+# Max Count of documents to process per page when marking bots with "stats-util" commandline. Defaults to 10.
+# This will affect the performance of the "./dspace stats-utils -m". If this number is too big, could raise OOM (OutOfMemory) 
+# exceptions; if the number is too small, then the command will take longer to execute.
+# spiders.resultProcessor.maxDocuments = 1000

--- a/dspace/config/modules/solr-statistics.cfg
+++ b/dspace/config/modules/solr-statistics.cfg
@@ -35,4 +35,4 @@ spiderips.urls = http://iplists.com/google.txt, \
 # Max Count of documents to process per page when marking bots with "stats-util" commandline. Defaults to 10.
 # This will affect the performance of the "./dspace stats-utils -m". If this number is too big, could raise OOM (OutOfMemory) 
 # exceptions; if the number is too small, then the command will take longer to execute.
-# spiders.resultProcessor.maxDocuments = 1000
+# spiderDetector.batchUpdateSize = 1000


### PR DESCRIPTION
Now, the "stats-utils -m" and "stats-utils -i" check if a register is a bot by IP, UserAgent and Domain (Reverse DNS Lookup).

A configuration option was added in order to increment performance of robot marking, if desired.
La configuración `maxDocumetsPerProcess` determina el número máximo a registros a marcar durante la escritura en el índice, es decir, esta propiedad define la cantidad máxima de registros por tanda que son actualizados por cada patrón de "userAgent" y "domain". Un marcado de bots puede realizarse en varias tandas de escritura. Mientras mas alta este valor, se espera que sea mas eficiente el proceso de marcado.

**CHECK**: no pude correr el _marcado_ de bots por completo porque dura varias horas; especialmente tarda en el marcado por userAgents. La _eliminación_ al parecer esta funcionando correctamente.