### PR TITLE
#4951 Normalizar paréntesis en búsqueda de Tesauros

### DIFF
--- a/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/SPARQLAuthorityProvider.java
+++ b/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/SPARQLAuthorityProvider.java
@@ -92,6 +92,8 @@ public abstract class SPARQLAuthorityProvider implements ChoiceAuthority {
 			int limit) {
 
 		parameterizedSparqlString.setParams(globalParameters);
+		normalizeTextForHttpQuery(parameterizedSparqlString);
+
 		Query query = QueryFactory.create(parameterizedSparqlString.toString(),
 				this.getSPARQLSyntax());
 		query.setOffset(offset);
@@ -118,6 +120,13 @@ public abstract class SPARQLAuthorityProvider implements ChoiceAuthority {
 					+ "ms");
 		}
 		return choices;
+	}
+
+	private void normalizeTextForHttpQuery(ParameterizedSparqlString parameterizedSparqlString) {
+		String aux = parameterizedSparqlString.getCommandText();
+		if (aux.indexOf("\\(") >= 0) aux = aux.replace("\\(", "\\\\\\\\\\(");
+		if (aux.indexOf("\\)") >= 0) aux = aux.replace("\\)", "\\\\\\\\\\)");
+		parameterizedSparqlString.setCommandText(aux);
 	}
 
 

--- a/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/TesauroAuthority.java
+++ b/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/TesauroAuthority.java
@@ -53,6 +53,8 @@ public class TesauroAuthority extends SimpleSPARQLAuthorityProvider {
 			break;
 		}
 		
+		text = normalizeTextForParserSPARQL10(text);
+
 		pqs.setNsPrefix("skos", NS_SKOS);
 		pqs.setNsPrefix("sedici", NS_SEDICI);
 
@@ -67,6 +69,12 @@ public class TesauroAuthority extends SimpleSPARQLAuthorityProvider {
 		pqs.append("ORDER BY ASC(?label)\n");
 		
 		return pqs;
+	}
+
+	private String normalizeTextForParserSPARQL10(String text) {
+		if (text.indexOf("(") >= 0) text = text.replace("(", "\\\\(");
+		if (text.indexOf(")") >= 0) text = text.replace(")", "\\\\)");
+		return text;
 	}
 
 	@Override


### PR DESCRIPTION
 Al parsear parentesis en la búsqueda de tesauros, se rompía la clase _com.hp.hpl.jena.sparql.lang.ParserSPARQL10.java_. También fue necesario normalizar los parentesis
 en _com.hp.hpl.jena.sparql.lang.ParserSPARQL10.java_ porque sino devolvia un 400 desde Drupal.

Por ejemplo, cuando un usuario ingresaba "Licenciado en Música (orientación Dirección Orquestal", no se mostraba ningun resultado y saltaba el siguiente error en el log de cocoon.

```
Caused by: com.hp.hpl.jena.query.QueryParseException: Lexical error at line 7, column 45.  Encountered: "(" (40), after : "\'Licenciado en Música \\"
	at com.hp.hpl.jena.sparql.lang.ParserSPARQL10.perform(ParserSPARQL10.java:110)
```
Una vez que se normalizo esa parte noté que aun faltaba normalizar el string que se envía al Drupal, ya que se ve que parser de PHP se maneja de otra manera. El error que tiraba cocoon era:

```
Caused by: HttpException: 400
	at com.hp.hpl.jena.sparql.engine.http.HttpQuery.rewrap(HttpQuery.java:414)
	at com.hp.hpl.jena.sparql.engine.http.HttpQuery.execGet(HttpQuery.java:358)
```
Nota: No se porque pero es necesario poner los acentos en la búsqueda cuando se ingresa un parentesis.