### PR TITLE
 "#4682" Agrego el subtipo "Convenio" para "Documento institucional"

### DIFF
--- a/dspace/config/crosswalks/oai/transformers/driver-commons.xsl
+++ b/dspace/config/crosswalks/oai/transformers/driver-commons.xsl
@@ -211,6 +211,9 @@
 			<xsl:when test="$subtype='Resolucion'">
 				info:eu-repo/semantics/annotation
 			</xsl:when>
+			<xsl:when test="$subtype='Convenio'">
+				info:eu-repo/semantics/annotation
+			</xsl:when>
 			<xsl:when test="$subtype='Imagen fija'">
 				info:eu-repo/semantics/other
 			</xsl:when> 
@@ -250,6 +253,9 @@
 				info:eu-repo/semantics/publishedVersion
 			</xsl:when>
 			<xsl:when test="$subtype='Comunicacion'">
+				info:eu-repo/semantics/publishedVersion
+			</xsl:when>
+			<xsl:when test="$subtype='Convenio'">
 				info:eu-repo/semantics/publishedVersion
 			</xsl:when>
 			<xsl:when test="$subtype='Revision'">

--- a/dspace/config/crosswalks/oai/xoai.xml
+++ b/dspace/config/crosswalks/oai/xoai.xml
@@ -514,6 +514,7 @@
 					<string>Edicion de Revista</string>
 					<string>Boletin</string>
 					<string>Conjunto de datos</string>
+					<string>Convenio</string>
                 </list>
             </Configuration>
         </CustomCondition>

--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -1426,6 +1426,10 @@
 				<displayed-value>Documento institucional</displayed-value>
 				<stored-value>Documento institucional</stored-value>
 			</pair>
+			<pair>
+				<displayed-value>Convenio</displayed-value>
+				<stored-value>Convenio</stored-value>
+			</pair>
 		</value-pairs>
 
 		<value-pairs value-pairs-name="common_subtypes_imagen_fija" dc-term="type">


### PR DESCRIPTION
La idea es que agregando el subtipo "Convenio"  se puedan mostrar mejor los convenios de la UNLP desde el portal de la UNLP via OpenSearch. Este subtipo no debe exponerse en el contexto SNRD
