### PR TITLE
Ticket#5006 Se creó un workflow genérico para manejar los casos de administradores de comunidad

### DIFF
--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/Role.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/Role.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.xmlworkflow;
 
+import org.dspace.content.Community;
 import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
@@ -35,6 +36,7 @@ public class Role {
     public static enum Scope{
         REPOSITORY,
         COLLECTION,
+        COMM_ADMINS,
         ITEM
     }
 
@@ -87,6 +89,24 @@ public class Role {
                 return assignees;
             }
             return new RoleMembers();
+        }
+        if (scope == Scope.COMM_ADMINS) {
+        	/*
+    		 * This scope references to the first community with "admins" group.
+    		 */
+    		Community communityWithAdmins = null;
+    		for (Community pCommunity : wfi.getCollection().getCommunities()) {
+    			if(pCommunity.getAdministrators() != null) {
+    				//Break at first community administrator group found...
+    				communityWithAdmins = pCommunity;
+    				break;
+    			}
+    		}
+    		RoleMembers adminMembers = new RoleMembers();
+    		if(communityWithAdmins != null){
+    			adminMembers.addGroup(communityWithAdmins.getAdministrators());
+    		}
+    		return adminMembers;
         }else{
             WorkflowItemRole[] roles = WorkflowItemRole.find(context, wfi.getID(), id);
             RoleMembers assignees = new RoleMembers();

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/WorkflowFactory.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/WorkflowFactory.java
@@ -250,6 +250,9 @@ public class WorkflowFactory {
             if(roleScope.equalsIgnoreCase("repository"))
                 scope = Role.Scope.REPOSITORY;
             else
+            	if(roleScope.equalsIgnoreCase("comm_admins"))
+            		scope = Role.Scope.COMM_ADMINS;
+            else
                 throw new WorkflowConfigurationException("An invalid role scope has been specified it must either be item or collection.");
 
             Role role = new Role(roleID, roleName, roleDescription,internal, scope);

--- a/dspace/config/workflow.xml
+++ b/dspace/config/workflow.xml
@@ -4,26 +4,23 @@
         <name-map collection="default" workflow="default"/>
         <name-map collection="10915/50" workflow="autoarchive"/>
         <name-map collection="10915/28975" workflow="autoarchive"/>
-        <name-map handle="10915/27347" workflow="MuseoFisicaWF"/>
-        <name-map handle="10915/68094" workflow="MuseoAstroGeofisicaWF"/>
-        <name-map handle="10915/27269" workflow="MuseoAzzariniWF"/>
-        <name-map handle="10915/41027" workflow="MuseoBibliotecaPublicaWF"/>
         <name-map collection="10915/46286" workflow="autoarchiveTesisDeGrado"/>
     </workflow-map>
 
     <!--Workflow modificado para SeDiCI-->
     <!-- 
     	Roles:
-    	- CollectionAdmin: revisores a nivel de coleccion (ej.: bibliotecarios) a quienes se delega
+    	- CollectionAdmin: revisores a nivel de coleccion/comunidad (ej.: bibliotecarios) a quienes se delega
     					una primera revisión y corrección de los documentos enviados.
     	- SeDiCIAdmin: revisores para todas las colecciones. Se corresponde con un Group en la aplicación,
     					 cuyos miembros son responsables de la revisión y aceptación final de cada 
     					 documento (haya pasado o no por la revisión del CollectionAdmin)
     					 
     	Pasos de revisión:
-    	- (Paso 1) CollectionLevelReview: ejecutable por el rol CollectionAdmin. Su ejecución se
-    					   determina a nivel de Collection, creando el grupo COLLECTION_X_WORKFLOW_ROLE_CollectionAdmin 
-    					   (desde la administración de la colección X) y asignando usuarios al mismo. Si este grupo 
+    	- (Paso 1) CollectionLevelReview: ejecutable por el rol CommAdmin. Su ejecución se
+    					   determina a nivel de las Community padre de la Collection vinculada al workflow, 
+    					   creando el grupo COMMUNITY_X_ADMIN (desde la administración de la Comunidad X, padre de
+    					   la coleccion vinculada al workflow) y asignando usuarios al mismo. Si este grupo 
     					   no existe o no posee usuarios, este paso del workflow se omite y el recurso pasa 
     					   directamente al siguiente paso.
     	- (Paso 2) SeDiCILevelReview: ejecutable por el rol SeDiCIAdmin. La intención es que siempre se ejecute este paso,
@@ -44,12 +41,12 @@
     <workflow start="CollectionLevelReview" id="default">
 
         <roles>
-            <role id="CollectionAdmin" name="CollectionAdmin" scope="collection" description="Este paso le permite a un revisor de la Colección, editar los metadatos y aceptar o rechazar el envío"/>
+            <role id="CommAdmin" name="CommAdmin" scope="comm_admins" description="Este paso le permite a un administrador de una Comunidad padre, editar los metadatos y aceptar o rechazar el envío"/>
             <role id="SeDiCIAdmin" name="SeDiCIAdmin" scope="repository" description="Este paso le permite a los administradores de SeDiCI editar los metadatos, aceptar o rechazar el envío"/>
         </roles>
 
 		<!-- PASO 1: Revisión a nivel de colección (aplicable por colección) -->
-        <step id="CollectionLevelReview" role="CollectionAdmin" userSelectionMethod="acceptRoleOrNotAdmin">
+        <step id="CollectionLevelReview" role="CommAdmin" userSelectionMethod="acceptRoleOrNotAdmin">
             <outcomes>
                 <step status="0">SeDiCILevelReview</step>
             </outcomes>
@@ -80,110 +77,6 @@
                 <action id="selectcollectionaction"/>
             </actions>
         </step>
-    </workflow>
-
-  <workflow start="CollectionLevelReview" id="MuseoFisicaWF">
-
-        <roles>
-            <role id="MuseoFisicaAdmin" name="MuseoFisicaAdmin" scope="repository" description="Este paso le permite a un revisor del museo de fisica, editar los metadatos y aceptar o rechazar el envío"/>
-            <role id="SeDiCIAdmin" name="SeDiCIAdmin" scope="repository" description="Este paso le permite a los administradores de SeDiCI editar los metadatos, aceptar o rechazar el envío"/>
-        </roles>
-
-        <!-- PASO 1: Revisión a nivel de colección (aplicable por colección) -->
-        <step id="CollectionLevelReview" role="MuseoFisicaAdmin" userSelectionMethod="acceptRoleOrNotAdmin">
-            <outcomes>
-                <step status="0">SeDiCILevelReview</step>
-            </outcomes>
-            <actions>
-                <action id="editaction"/>
-            </actions>
-        </step>
-        
-        <!-- PASO 2: Revisión a nivel de SeDiCI (aplicable a todos los ítems de todo el repositorio) -->
-        <step id="SeDiCILevelReview" role="SeDiCIAdmin" userSelectionMethod="claimaction">
-            <actions>
-                <action id="editaction"/>
-            </actions>
-        </step>
-        
-    </workflow>
-
-    <workflow start="CollectionLevelReview" id="MuseoAstroGeofisicaWF">
-
-        <roles>
-            <role id="MuseoAstroGeofisicaAdmin" name="MuseoAstroGeofisicaAdmin" scope="repository" description="Este paso le permite a un revisor del museo de fisica, editar los metadatos y aceptar o rechazar el envío"/>
-            <role id="SeDiCIAdmin" name="SeDiCIAdmin" scope="repository" description="Este paso le permite a los administradores de SeDiCI editar los metadatos, aceptar o rechazar el envío"/>
-        </roles>
-
-        <!-- PASO 1: Revisión a nivel de colección (aplicable por colección) -->
-        <step id="CollectionLevelReview" role="MuseoAstroGeofisicaAdmin" userSelectionMethod="acceptRoleOrNotAdmin">
-            <outcomes>
-                <step status="0">SeDiCILevelReview</step>
-            </outcomes>
-            <actions>
-                <action id="editaction"/>
-            </actions>
-        </step>
-
-        <!-- PASO 2: Revisión a nivel de SeDiCI (aplicable a todos los ítems de todo el repositorio) -->
-        <step id="SeDiCILevelReview" role="SeDiCIAdmin" userSelectionMethod="claimaction">
-            <actions>
-                <action id="editaction"/>
-            </actions>
-        </step>
-
-    </workflow>
-
-  <workflow start="CollectionLevelReview" id="MuseoAzzariniWF">
-
-        <roles>
-            <role id="MuseoAzzariniAdmin" name="MuseoAzzariniAdmin" scope="repository" description="Este paso le permite a un revisor del museo Azzarini editar los metadatos y aceptar o rechazar el envío"/>
-            <role id="SeDiCIAdmin" name="SeDiCIAdmin" scope="repository" description="Este paso le permite a los administradores de SeDiCI editar los metadatos, aceptar o rechazar el envío"/>
-        </roles>
-
-        <!-- PASO 1: Revisión a nivel de colección (aplicable por colección) -->
-        <step id="CollectionLevelReview" role="MuseoAzzariniAdmin" userSelectionMethod="acceptRoleOrNotAdmin">
-            <outcomes>
-                <step status="0">SeDiCILevelReview</step>
-            </outcomes>
-            <actions>
-                <action id="editaction"/>
-            </actions>
-        </step>
-        
-        <!-- PASO 2: Revisión a nivel de SeDiCI (aplicable a todos los ítems de todo el repositorio) -->
-        <step id="SeDiCILevelReview" role="SeDiCIAdmin" userSelectionMethod="claimaction">
-            <actions>
-                <action id="editaction"/>
-            </actions>
-        </step>
-        
-    </workflow>
-
-  <workflow start="CollectionLevelReview" id="MuseoBibliotecaPublicaWF">
-
-        <roles>
-            <role id="MuseoBibliotecaPublicaAdmin" name="MuseoBibliotecaPublicaAdmin" scope="repository" description="Este paso le permite a un revisor del museo de la biblioteca pública, editar los metadatos y aceptar o rechazar el envío"/>
-            <role id="SeDiCIAdmin" name="SeDiCIAdmin" scope="repository" description="Este paso le permite a los administradores de SeDiCI editar los metadatos, aceptar o rechazar el envío"/>
-        </roles>
-
-        <!-- PASO 1: Revisión a nivel de colección (aplicable por colección) -->
-        <step id="CollectionLevelReview" role="MuseoBibliotecaPublicaAdmin" userSelectionMethod="acceptRoleOrNotAdmin">
-            <outcomes>
-                <step status="0">SeDiCILevelReview</step>
-            </outcomes>
-            <actions>
-                <action id="editaction"/>
-            </actions>
-        </step>
-        
-        <!-- PASO 2: Revisión a nivel de SeDiCI (aplicable a todos los ítems de todo el repositorio) -->
-        <step id="SeDiCILevelReview" role="SeDiCIAdmin" userSelectionMethod="claimaction">
-            <actions>
-                <action id="editaction"/>
-            </actions>
-        </step>
-        
     </workflow>
 
     <workflow id="autoarchiveTesisDeGrado" start="SeDiCILevelReview">

--- a/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/xmlworkflow/state/actions/processingaction/AcceptRoleOrNotAdmin.java
+++ b/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/xmlworkflow/state/actions/processingaction/AcceptRoleOrNotAdmin.java
@@ -15,10 +15,21 @@ public class AcceptRoleOrNotAdmin extends ClaimAction {
 	 * an upper community,then evaluate if exists users that can handle the actions of the current step.
 	 */
 	public boolean isValidUserSelection(Context ctx, XmlWorkflowItem wfi, boolean hasUI) throws WorkflowConfigurationException, SQLException {
+		boolean authsIsTurnedOff = ctx.ignoreAuthorization();
+		//If authorizaton system was initially turned off, then restore it...
+		if(authsIsTurnedOff) {
+			ctx.restoreAuthSystemState();
+		}
+		boolean isValid;
 		if (isUserMemberInStepRole(ctx,wfi) || !AuthorizeManager.isAdmin(ctx, wfi.getCollection()))
-			return super.isValidUserSelection(ctx, wfi, hasUI);
+			isValid = super.isValidUserSelection(ctx, wfi, hasUI);
 		else
-			return false;
+			isValid = false;
+		//Finally, if authorizaton system was initially turned off, then turn off again...
+		if(authsIsTurnedOff) {
+			ctx.turnOffAuthorisationSystem();
+		}
+		return isValid;
 	}
 	/*
 	 * @return true if current user is member of the role configured for the current step. 


### PR DESCRIPTION
Se eliminaron los antiguos workflows especificos por administradores de comunidad (p.e. MuseoAstroGeofisicaWF, MuseoAzzariniWF, etc.) para dar lugar a una nueva configuración de workflow genérica que permite el mismo funcionamiento que estos worflows especificos pero sin configurar cada caso en particular.

La configuracion quedó algo así:
```xml
<!-- Workflow general -->
<workflow start="CollectionLevelReview" id="default">

    <roles>
        <role id="CommAdmin" name="CommAdmin" scope="comm_admins" description="Este paso le permite a un administrador de una Comunidad padre, editar los metadatos y aceptar o rechazar el envío"/>
        <role id="SeDiCIAdmin" name="SeDiCIAdmin" scope="repository" description="Este paso le permite a los administradores de SeDiCI editar los metadatos, aceptar o rechazar el envío"/>
    </roles>

    <!-- PASO 1: Revisión a nivel de colección (aplicable por colección) -->
    <step id="CollectionLevelReview" role="CommAdmin" userSelectionMethod="acceptRoleOrNotAdmin">
    <!-- ... ... ... -->
    </step>

    <!-- PASO 2: Revisión a nivel de SeDiCI (aplicable a todos los ítems de todo el repositorio) -->
    <step id="SeDiCILevelReview" role="SeDiCIAdmin" userSelectionMethod="claimaction">
    <!-- ... ... ... -->
    </step>
</workflow>
```

Para esto, se agregó un nuevo tipo de _Role_ llamado **COMM_ADMINS**, que, a partir de la activación del workflow sobre el envío en una Colección específica, busca hacia arriba el primer **grupo de Administradores** que encuentre asociado en alguna de las Comunidades padre de esa Colección. Si este grupo de administradores no está vacío, entonces se le asigna el primer paso del workflow a alguno de sus miembros; luego será revisado por un SEDICI-ADMIN.

Se sigue utilizando como _userSelectionMethod_ el metodo "acceptRoleOrNotAdmin". A este ultimo se le hicieron algunos arreglos ya que presentaba algunos errores para el caso de que el envío lo hubiese realizado un usuario con permisos de ADD. Estos caso particular de error apareció luego de la migracion a DS_5X.

------
**NOTA**: en la BBDD se deben buscar todas las pool tasks que hacen referencias a los workflows que serán eliminados, y hacer algo al respecto con estas, para evitar problemas en el futuro...