### PR TITLE
-#5039 Ahora está normalizada la búsqueda con paréntesis en ChoiceAuthorities

### DIFF
--- a/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/AuthorAuthority.java
+++ b/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/AuthorAuthority.java
@@ -91,6 +91,7 @@ public class AuthorAuthority extends AdvancedSPARQLAuthorityProvider {
 					+ "} \n"); // end 3er optional
 		pqs.append("	}\n"); //end del 2do optional
 		if (!"".equals(text)) {
+			text = normalizeTextForParserSPARQL10(text);
 			String[] tokens = text.split(",");
 			if (tokens.length > 1 && tokens[0].trim().length() > 0 && tokens[1].trim().length() > 0) {
 				pqs.append("FILTER(REGEX(?name, ?text2, \"i\") && REGEX(?surname, ?text1, \"i\"))\n");

--- a/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/InstitutionAuthority.java
+++ b/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/InstitutionAuthority.java
@@ -41,6 +41,7 @@ public class InstitutionAuthority extends SimpleSPARQLAuthorityProvider {
 		pqs.append("OPTIONAL { ?institution skos:broader ?padre . ?padre foaf:name ?labelpadre  OPTIONAL { ?padre sioc:id  ?initpadre } . } \n");    
 		if (!"".equals(text)) {
 			pqs.append("FILTER(REGEX(?label, ?text, \"i\") || REGEX(?initials, ?text, \"i\"))\n");
+			text = normalizeTextForParserSPARQL10(text);
 			pqs.setLiteral("text", text.trim());
 		}
 		pqs.append("}\n");

--- a/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/SPARQLAuthorityProvider.java
+++ b/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/SPARQLAuthorityProvider.java
@@ -92,9 +92,8 @@ public abstract class SPARQLAuthorityProvider implements ChoiceAuthority {
 			int limit) {
 
 		parameterizedSparqlString.setParams(globalParameters);
-		normalizeTextForHttpQuery(parameterizedSparqlString);
 
-		Query query = QueryFactory.create(parameterizedSparqlString.toString(),
+		Query query = QueryFactory.create(normalizeTextForHttpQuery(parameterizedSparqlString.toString()),
 				this.getSPARQLSyntax());
 		query.setOffset(offset);
 
@@ -122,11 +121,24 @@ public abstract class SPARQLAuthorityProvider implements ChoiceAuthority {
 		return choices;
 	}
 
-	private void normalizeTextForHttpQuery(ParameterizedSparqlString parameterizedSparqlString) {
-		String aux = parameterizedSparqlString.getCommandText();
-		if (aux.indexOf("\\(") >= 0) aux = aux.replace("\\(", "\\\\\\\\\\(");
-		if (aux.indexOf("\\)") >= 0) aux = aux.replace("\\)", "\\\\\\\\\\)");
-		parameterizedSparqlString.setCommandText(aux);
+	private String normalizeTextForHttpQuery(String query) {
+		if (query.indexOf("\\(") >= 0) {
+			query = query.replace("\\(", "\\\\\\(");
+		}
+		if (query.indexOf("\\)") >= 0) {
+			query = query.replace("\\)", "\\\\\\)");
+		}
+		return query;
+	}
+
+	protected String normalizeTextForParserSPARQL10(String text) {
+		if (text.indexOf("(") >= 0) {
+			text = text.replace("(", "\\\\(");
+		}
+		if (text.indexOf(")") >= 0) {
+			text = text.replace(")", "\\\\)");
+		}
+		return text;
 	}
 
 

--- a/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/TesauroAuthority.java
+++ b/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/TesauroAuthority.java
@@ -63,7 +63,8 @@ public class TesauroAuthority extends SimpleSPARQLAuthorityProvider {
 		pqs.append("?term a "+ rdfType +"; skos:prefLabel ?label .\n");
 		pqs.append("OPTIONAL { ?term skos:broader ?parent . ?parent skos:prefLabel ?parentLabel } \n");
 		if (!"".equals(text.trim())) {
-			pqs.append("FILTER(REGEX(?label, '"+text.trim()+"', 'i'))\n");
+			pqs.append("FILTER(REGEX(?label, ?text, 'i'))\n");
+			pqs.setLiteral("text", text.trim());
 		}
 		pqs.append("}\n");
 		pqs.append("ORDER BY ASC(?label)\n");

--- a/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/TesauroAuthority.java
+++ b/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/TesauroAuthority.java
@@ -71,12 +71,6 @@ public class TesauroAuthority extends SimpleSPARQLAuthorityProvider {
 		return pqs;
 	}
 
-	private String normalizeTextForParserSPARQL10(String text) {
-		if (text.indexOf("(") >= 0) text = text.replace("(", "\\\\(");
-		if (text.indexOf(")") >= 0) text = text.replace(")", "\\\\)");
-		return text;
-	}
-
 	@Override
 	protected Choice extractChoice(QuerySolution solution) {
 		String key = solution.getResource("term").getURI();


### PR DESCRIPTION
Corregí la función normalizeTextForHttpQuery en SPARQLAuthorityProvider, y agregué la normalización en la búsqueda de autores e instituciones, no solo para tesauros.