### PR TITLE
-#4438 Ahora se permite múltiples grupos en el <required-on-group>

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/DCInput.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/DCInput.java
@@ -536,35 +536,55 @@ public class DCInput
     	return group;
     }
     
+    /**
+     * Evaluates all conditions in visibility-on-group. If any is true, then the all expression is true.
+     */
     public boolean isVisibleOnGroup(Context context) throws SQLException, AuthorizeException {
     	
     	if(!hasVisibilityOnGroup())
     		return true;
     	
-    	boolean isVisible = false;
     	for(String groupName : getVisibilityRestrictions()) {
     		Group group = findGroup(context, groupName);
         	if( group == null) {
         		throw new AuthorizeException("Group "+groupName+ " does not exist, check your input_forms.xml");
         	}
-        	isVisible = isVisible || !(Group.isMember(context, group.getID()) ^ isVisibilityPositiveRestriction(groupName)); 
+            if(isVisibilityPositiveRestriction(groupName)) {
+                if(Group.isMember(context, group.getID())) {
+                    return true;
+                }
+            } else { //if not positive
+                if(!Group.isMember(context, group.getID())) {
+                    return true;
+                }
+            }
     	}
-		return isVisible;
+		return false;
     }
 
+    /**
+     * Evaluates all conditions in required-on-group. If any is true, then the all expression is true.
+     */
     public boolean isRequiredOnGroup(Context context) throws SQLException, AuthorizeException {
 	    if(!isGroupBased()) {
 	        return true;
 	    }
-	    boolean isRequired = false;
 	    for(String groupName : getRequiredRestrictions()) {
 	        Group group = findGroup(context, groupName);
 	        if( group == null) {
 	            throw new AuthorizeException("Group "+groupName+ " does not exist, check your input_forms.xml");
 	        }
-	        isRequired = isRequired || !(Group.isMember(context, group.getID()) ^ isRequiredPositiveRestriction(groupName)); 
+	        if(isRequiredPositiveRestriction(groupName)) {
+	            if(Group.isMember(context, group.getID())) {
+	                return true;
+	            }
+	        } else { //if not positive
+	            if(!Group.isMember(context, group.getID())) {
+                    return true;
+                }
+	        }
 	    }
-	    return isRequired;
+	    return false;
     }
 	
     /* SEDICI-END */

--- a/dspace-api/src/main/java/org/dspace/submit/step/DescribeStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/DescribeStep.java
@@ -346,12 +346,7 @@ public class DescribeStep extends AbstractProcessingStep
                 // Group-based restriction validation
                 if(inputs[i].isGroupBased()) 
                 {
-                	Group group = findGroup(context, inputs[i].getGroup());
-                	if( group == null) 
-                	{
-                		log.warn("Group "+inputs[i].getGroup()+ " does not exist, check your input_forms.xml" );
-                	}
-                	else if (!(Group.isMember(context, group.getID()) ^ inputs[i].hasToBeMemeber()) && values.length == 0 ) 
+                    if (inputs[i].isRequiredOnGroup(context) && values.length == 0 )
                 	{
                 		// agrega el campo faltante a la lista de errores 
                         addErrorField(request, getFieldName(inputs[i]));


### PR DESCRIPTION
- [x] Probar funcionamiento de configuración `<required-on-group>`
- [x] Probar funcionamiento de configuración `<visibility-on-group>`

- - - 
Se agregó la lógica necesaria para permitir la configuración de múltiples groupos en la tag `<required-on-group>` del input-forms.xml. Se evalua con una lógica de OR, es decir, que ante la primer condición que se da verdadera, el required es verdadero. Por ejemplo:

**1.** El usuario pertenec al grupo "Biblioteca", y se tiene la siguiente configuración:
```xml
<required-on-group>SeDiCIAdmin,MuseoFísica,Biblioteca</required-on-group>
```
Entonces el campo es requerido porque la condición de pertenecer al grupo "Biblioteca" es válida.

**2.** El usuario pertenece al grupo "Biblioteca", y se tiene la siguiente configuración:
```xml
<required-on-group>!SeDiCIAdmin</required-on-group>
```
Entonces el campo es requerido porque la condición de NO pertenecer a "SeDiCIAdmin" es verdadera.

**3.** El usuario pertenece al grupo "Biblioteca", y se tiene la siguiente configuración:
```xml
<required-on-group>MuseoFísica</required-on-group>
```
Entonces el campo no es requerido para este usuario, ya que NO pertenece al grupo MuseoFísica.

Por último, la lógica de `<visibility-on-group>` fue simplificada para evitar el uso de XOR que compliquen el análisis de los casos. 