### PR TITLE
Ticket#2103 Creé la tarea de curation MetadataAuthorityQualityControl

### DIFF
--- a/dspace/config/modules/curate.cfg
+++ b/dspace/config/modules/curate.cfg
@@ -8,6 +8,7 @@
 
 plugin.named.org.dspace.curate.CurationTask = \
     org.dspace.ctask.general.NoOpCurationTask = noop, \
+    ar.edu.unlp.sedici.dspace.curation.MetadataAuthorityQualityControl = metadataauthorityqualitycontrol, \
     org.dspace.ctask.general.ProfileFormats = profileformats, \
     org.dspace.ctask.general.RequiredMetadata = requiredmetadata, \
     org.dspace.ctask.general.ClamScan = vscan, \

--- a/dspace/config/modules/metadataauthorityqualitycontrol.cfg
+++ b/dspace/config/modules/metadataauthorityqualitycontrol.cfg
@@ -1,0 +1,23 @@
+#-------------------------------------------------------------------------------#
+#--------------METADATAAUTORITYQUALITYCONTROL CURATION TASK CONFIGURATIONS------#
+#-------------------------------------------------------------------------------#
+
+#Fix mode, reports and fixes metadata errors and inconsistencies
+#metadataauthorityqualitycontrol.fixmode = false
+
+#Fix variants mode, also fixes metadata value variants
+#metadataauthorityqualitycontrol.fixVariants = false
+
+#Fix missing authorities mode, also tries to find an authority key
+#for those metadata with a missing authority key.
+#metadataauthorityqualitycontrol.fixMissing = false
+
+#Fix dangling authorities mode, also unsets every authority key which is not connected with any authority
+#metadataauthorityqualitycontrol.fixDangling = false
+
+#List of metadata_fields which are authority controlled but we
+#don't want the curation task to process
+#metadataauthorityqualitycontrol.skipMetadata =
+
+#List of metadata_fields we want the curation task to process, "*" = all authority controlled metadata. Defaults to an empty list of processing.
+#metadataauthorityqualitycontrol.checkMetadata =

--- a/dspace/config/modules/metadataauthorityqualitycontrol.cfg
+++ b/dspace/config/modules/metadataauthorityqualitycontrol.cfg
@@ -3,21 +3,21 @@
 #-------------------------------------------------------------------------------#
 
 #Fix mode, reports and fixes metadata errors and inconsistencies
-#metadataauthorityqualitycontrol.fixmode = false
+#fixmode = false
 
 #Fix variants mode, also fixes metadata value variants
-#metadataauthorityqualitycontrol.fixVariants = false
+#fixVariants = false
 
 #Fix missing authorities mode, also tries to find an authority key
 #for those metadata with a missing authority key.
-#metadataauthorityqualitycontrol.fixMissing = false
+#fixMissing = false
 
 #Fix dangling authorities mode, also unsets every authority key which is not connected with any authority
-#metadataauthorityqualitycontrol.fixDangling = false
+#fixDangling = false
 
 #List of metadata_fields which are authority controlled but we
 #don't want the curation task to process
-#metadataauthorityqualitycontrol.skipMetadata =
+#skipMetadata =
 
 #List of metadata_fields we want the curation task to process, "*" = all authority controlled metadata. Defaults to an empty list of processing.
-#metadataauthorityqualitycontrol.checkMetadata =
+#checkMetadata =

--- a/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/curation/MetadataAuthorityQualityControl.java
+++ b/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/curation/MetadataAuthorityQualityControl.java
@@ -2,25 +2,25 @@ package ar.edu.unlp.sedici.dspace.curation;
 
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
-import org.dspace.content.MetadataField;
-import org.dspace.content.MetadataValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.authority.ChoiceAuthorityManager;
 import org.dspace.content.authority.Choices;
 import org.dspace.content.authority.MetadataAuthorityManager;
 import org.dspace.curate.AbstractCurationTask;
 import org.dspace.curate.Curator;
 import java.io.IOException;
-import java.util.List;
+import java.sql.SQLException;
 
 /**
- * Curation task that checks each authority controlled metadata of an item, reports anomalies and optionally fix them
+ * Curation task that checks each authority controlled metadata of an item,
+ * reports anomalies and optionally fix them
  *
  */
 public class MetadataAuthorityQualityControl extends AbstractCurationTask {
 
-	private MetadataAuthorityManager authService = MetadataAuthorityManager.getManager();
+	private MetadataAuthorityManager authManager = MetadataAuthorityManager.getManager();
 
-	private ChoiceAuthorityManager choiceAuthorityService = ChoiceAuthorityManager.getManager()();
+	private ChoiceAuthorityManager choiceAuthorityManager = ChoiceAuthorityManager.getManager();
 
 	/**
 	 * Configuration property. If true, curation task fixes the metadata errors by
@@ -29,22 +29,22 @@ public class MetadataAuthorityQualityControl extends AbstractCurationTask {
 	private boolean fixmode = false;
 
 	/**
-	 * Configuration property, only works with fixmode in true.
-	 * If true, curation task also fixes metadata value variants.
+	 * Configuration property, only works with fixmode in true. If true, curation
+	 * task also fixes metadata value variants.
 	 */
 	private boolean fixvariants = false;
 
 	/**
-	 * Configuration property, only works with fixmode in true.
-	 * If true, curation task also unsets every authority key
-	 * which is not connected with any authority.
+	 * Configuration property, only works with fixmode in true. If true, curation
+	 * task also unsets every authority key which is not connected with any
+	 * authority.
 	 */
 	private boolean fixDangling = false;
 
 	/**
-	 * Configuration property, only works with fixmode in true.
-	 * If true, curation task also tries to find an authority key
-	 * for those metadata with a missing authority key.
+	 * Configuration property, only works with fixmode in true. If true, curation
+	 * task also tries to find an authority key for those metadata with a missing
+	 * authority key.
 	 */
 	private boolean fixMissing = false;
 
@@ -61,6 +61,8 @@ public class MetadataAuthorityQualityControl extends AbstractCurationTask {
 	 */
 	private String[] metadataToCheck;
 
+	private String mtFieldName;
+
 	@Override
 	public void init(Curator curator, String taskId) throws IOException {
 		super.init(curator, taskId);
@@ -70,8 +72,14 @@ public class MetadataAuthorityQualityControl extends AbstractCurationTask {
 			fixMissing = taskBooleanProperty("fixMissing", false);
 			fixDangling = taskBooleanProperty("fixDangling", false);
 		}
-		metadataToSkip = this.taskArrayProperty("skipMetadata");
-		metadataToCheck = this.taskArrayProperty("checkMetadata");
+		String metadataToSkipProperty = this.taskProperty("skipMetadata");
+		if (metadataToSkipProperty != null) {
+			metadataToSkip = metadataToSkipProperty.trim().split("[\\ ]*,[\\ ]*");
+		}
+		String metadataToCheckProperty = this.taskProperty("checkMetadata");
+		if (metadataToCheckProperty != null) {
+			metadataToCheck = metadataToCheckProperty.trim().split("[\\ ]*,[\\ ]*");
+		}
 	}
 
 	@Override
@@ -87,14 +95,17 @@ public class MetadataAuthorityQualityControl extends AbstractCurationTask {
 				reporter.append(" (WITHDRAWN)");
 			}
 			reporter.append(" ##########\n");
-			List<MetadataValue> mValues = itemService.getMetadata(item, Item.ANY, Item.ANY, Item.ANY, Item.ANY);
-			for (MetadataValue mv : mValues) {
-				//Only check metadata if it is authority controlled
-				if (authService.isAuthorityControlled(mv.getMetadataField()) && !skipMetadata(mv.getMetadataField())
-						&& isMetadataToCheck(mv.getMetadataField())) {
-					checkMetadataAuthority(reporter, mv, item);
+
+			Metadatum[] mValues = item.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
+			for (Metadatum mt : mValues) {
+				// Only check metadata if it is authority controlled
+				mtFieldName = mt.getField().replace(".", "_");
+				if (authManager.isAuthorityControlled(mtFieldName) && !skipMetadata(mtFieldName)
+						&& isMetadataToCheck(mtFieldName)) {
+					checkMetadataAuthority(reporter, mt, item);
 				}
 			}
+
 			report(reporter.toString());
 			status = Curator.CURATE_SUCCESS;
 		} else {
@@ -104,130 +115,141 @@ public class MetadataAuthorityQualityControl extends AbstractCurationTask {
 		return status;
 	}
 
-	private void checkMetadataAuthority(StringBuilder reporter, MetadataValue mv, Item item) {
-
-		if ((mv.getAuthority() == null || mv.getAuthority().isEmpty())
-				&& (mv.getValue() == null || mv.getValue().isEmpty())) {
-			report(reporter, mv, "ERROR", "Null both authority key and text_value");
-		} else if (mv.getAuthority() == null || mv.getAuthority().isEmpty()) {
-			checkMetadataWithoutAuthorityKey(reporter, mv, item);
+	private void checkMetadataAuthority(StringBuilder reporter, Metadatum mt, Item item) throws IOException {
+		Metadatum oldMt = mt.copy();
+		if ((mt.authority == null || mt.authority.isEmpty()) && (mt.value == null || mt.value.isEmpty())) {
+			report(reporter, mt, "ERROR", "Null both authority key and text_value");
+		} else if (mt.authority == null || mt.authority.isEmpty()) {
+			checkMetadataWithoutAuthorityKey(reporter, mt, item);
 		} else {
-			checkMetadataWithAuthorityKey(reporter, mv);
+			checkMetadataWithAuthorityKey(reporter, mt, item);
+		}
+		if (fixmode) {
+			item.replaceMetadataValue(oldMt, mt);
+			try {
+				item.update();
+			} catch (Exception e) {
+				throw new IOException(e);
+			}
 		}
 	}
 
 	/**
 	 * Reconciles metadata value with authority
+	 *
+	 * @throws IOException
 	 */
-	private void checkMetadataWithoutAuthorityKey(StringBuilder reporter, MetadataValue mv, Item item) {
-		//Null or empty authority, try to find one from the text_value
-		Choices choices = choiceAuthorityService.getBestMatch(mv.getMetadataField().toString(), mv.getValue(),
-				item.getOwningCollection(), mv.getLanguage());
-		if (authService.isAuthorityRequired(mv.getMetadataField())) {
-			report(reporter, mv, "ERROR", "Missing authority key for <<", mv.getValue(), ">>");
+	private void checkMetadataWithoutAuthorityKey(StringBuilder reporter, Metadatum mt, Item item) throws IOException {
+		// Null or empty authority, try to find one from the text_value
+		Choices choices;
+		try {
+			choices = choiceAuthorityManager.getBestMatch(mtFieldName, mt.value, item.getOwningCollection().getID(),
+					mt.language);
+		} catch (SQLException e) {
+			throw new IOException(e);
+		}
+		if (authManager.isAuthorityRequired(mtFieldName)) {
+			report(reporter, mt, "ERROR", "Missing authority key for <<", mt.value, ">>");
 		} else {
-			report(reporter, mv, "INFO", "Missing optional authority key for <<", mv.getValue(), ">>");
+			report(reporter, mt, "INFO", "Missing optional authority key for <<", mt.value, ">>");
 		}
 		if (choices.values.length > 0) {
-			//Authority found from the text_value
+			// Authority found from the text_value
 			String value = choices.values[0].value;
-			if (compare(value, mv.getValue())) {
-				//Exact match, new authority available
-				saveAuthorityKey(reporter, mv, choices);
+			if (compare(value, mt.value)) {
+				// Exact match, new authority available
+				saveAuthorityKey(reporter, mt, choices);
 			} else {
 				// do not fix because can be either a false positive or variant
-				report(reporter, mv, "INFO", "Recommended value <<", choices.values[0].authority, ">> with confidence ",
+				report(reporter, mt, "INFO", "Recommended value <<", choices.values[0].authority, ">> with confidence ",
 						String.valueOf(choices.confidence));
 			}
 		} else {
-			//Authority not found from the text_value, just check confidence
-			assertConfidenceNotFound(reporter, mv);
+			// Authority not found from the text_value, just check confidence
+			assertConfidenceNotFound(reporter, mt);
 		}
 
 	}
 
-	private void checkMetadataWithAuthorityKey(StringBuilder reporter, MetadataValue mv) {
-		String value = choiceAuthorityService.getLabel(mv.getMetadataField().toString(), mv.getAuthority(),
-				mv.getLanguage());
+	private void checkMetadataWithAuthorityKey(StringBuilder reporter, Metadatum mt, Item item) throws IOException {
+		String value = choiceAuthorityManager.getLabel(mtFieldName, mt.authority, mt.language);
 		if (value == null || value.isEmpty()) {
 			// Authority not found
-			saveDanglingAuthority(reporter, mv);
-		} else if (compare(value, mv.getValue())) {
+			saveDanglingAuthority(reporter, mt, item);
+		} else if (compare(value, mt.value)) {
 			// Authority found, value==text_value
-			assertConfidenceUncertain(reporter, mv);
+			assertConfidenceUncertain(reporter, mt);
 		} else {
 			// Authority found, but value!=text_value
-			saveVariant(reporter, mv, value);
+			saveVariant(reporter, mt, value);
 		}
 	}
 
-	private void assertConfidenceUncertain(StringBuilder reporter, MetadataValue mv) {
-		if (mv.getConfidence() < Choices.CF_UNCERTAIN) {
-			report(reporter, mv, "ERROR", ": Invalid confidence ", String.valueOf(mv.getConfidence()), ", expected ",
+	private void assertConfidenceUncertain(StringBuilder reporter, Metadatum mt) {
+		if (mt.confidence < Choices.CF_UNCERTAIN) {
+			report(reporter, mt, "ERROR", ": Invalid confidence ", String.valueOf(mt.confidence), ", expected ",
 					String.valueOf(Choices.CF_UNCERTAIN));
 			if (fixmode) {
-				mv.setConfidence(Choices.CF_UNCERTAIN);
-				report(reporter, mv, "FIXED", "[CONFIDENCE] confidence replaced with value ",
+				mt.confidence = Choices.CF_UNCERTAIN;
+				report(reporter, mt, "FIXED", "[CONFIDENCE] confidence replaced with value ",
 						String.valueOf(Choices.CF_UNCERTAIN));
 			}
 		}
 	}
 
-	private void assertConfidenceNotFound(StringBuilder reporter, MetadataValue mv) {
-		if (mv.getConfidence() > Choices.CF_NOTFOUND) {
-			report(reporter, mv, "ERROR", "Invalid confidence ", String.valueOf(mv.getConfidence()), ", expected ",
+	private void assertConfidenceNotFound(StringBuilder reporter, Metadatum mt) throws IOException {
+		if (mt.confidence > Choices.CF_NOTFOUND) {
+			report(reporter, mt, "ERROR", "Invalid confidence ", String.valueOf(mt.confidence), ", expected ",
 					String.valueOf(Choices.CF_NOTFOUND));
 			if (fixmode) {
-				mv.setConfidence(Choices.CF_NOTFOUND);
-				report(reporter, mv, "FIXED", "[CONFIDENCE] confidence replaced with value ",
+				mt.confidence = Choices.CF_NOTFOUND;
+				report(reporter, mt, "FIXED", "[CONFIDENCE] confidence replaced with value ",
 						String.valueOf(Choices.CF_NOTFOUND));
 			}
 		}
 	}
 
-	private void saveVariant(StringBuilder reporter, MetadataValue mv, String value) {
-		report(reporter, mv, "WARN", "Variant found. Authority  <<", mv.getAuthority(),
-				">>; Metadata text_value <<", mv.getValue(), ">>; Authority value <<", value, ">>");
+	private void saveVariant(StringBuilder reporter, Metadatum mt, String value) {
+		report(reporter, mt, "WARN", "Variant found. Authority  <<", mt.authority, ">>; Metadata text_value <<",
+				mt.value, ">>; Authority value <<", value, ">>");
 		if (fixvariants) {
-			mv.setValue(value);
-			mv.setConfidence(Choices.CF_UNCERTAIN);
-			report(reporter, mv, "FIXED", "[VARIANT] variant replaced with authority's value.");
+			mt.value = value;
+			mt.confidence = Choices.CF_UNCERTAIN;
+			report(reporter, mt, "FIXED", "[VARIANT] variant replaced with authority's value.");
 		}
 
 	}
 
-	private void saveAuthorityKey(StringBuilder reporter, MetadataValue mv, Choices choices) {
+	private void saveAuthorityKey(StringBuilder reporter, Metadatum mt, Choices choices) {
 		String newAuthority = choices.values[0].authority;
-		report(reporter, mv, "INFO", "Found Authority <<", newAuthority, ">> for value <<", mv.getValue(), ">>.");
+		report(reporter, mt, "INFO", "Found Authority <<", newAuthority, ">> for value <<", mt.value, ">>.");
 		if (fixMissing && choices.confidence >= Choices.CF_UNCERTAIN) {
-			mv.setAuthority(newAuthority);
-			mv.setConfidence(choices.confidence);
-			report(reporter, mv, "FIXED", "[MISSING AUTHORITY] Authority set with value <<", newAuthority, ">>");
+			mt.authority = newAuthority;
+			mt.confidence = choices.confidence;
+			report(reporter, mt, "FIXED", "[MISSING AUTHORITY] Authority set with value <<", newAuthority, ">>");
 		} else if (choices.confidence < Choices.CF_UNCERTAIN) {
-			report(reporter, mv, "NOT FIXED", "[AMBIGUOUS AUTHORITY] Authority key <<", newAuthority,
+			report(reporter, mt, "NOT FIXED", "[AMBIGUOUS AUTHORITY] Authority key <<", newAuthority,
 					">> is ambiguous for text_value");
 		}
 
 	}
 
-	private void saveDanglingAuthority(StringBuilder reporter, MetadataValue mv) {
-		report(reporter, mv, "ERROR", "Authority key <<", mv.getAuthority(), ">> not found");
-		assertConfidenceNotFound(reporter, mv);
+	private void saveDanglingAuthority(StringBuilder reporter, Metadatum mt, Item item) throws IOException {
+		report(reporter, mt, "ERROR", "Authority key <<", mt.authority, ">> not found");
+		assertConfidenceNotFound(reporter, mt);
 		if (fixDangling) {
-			mv.setAuthority(null);
-			report(reporter, mv, "FIXED", "[DANGLING AUTHORITY] Authority set with NULL");
-			checkMetadataWithoutAuthorityKey(reporter, mv, (Item) mv.getResourceId());
+			mt.authority = null;
+			report(reporter, mt, "FIXED", "[DANGLING AUTHORITY] Authority set with NULL");
+			checkMetadataWithoutAuthorityKey(reporter, mt, item);
 		}
 	}
 
-	private void report(StringBuilder reporter, MetadataValue value, String level, String... messages) {
-		reporter.append("- ").append(level).append(" (").append(value.getFieldId()).append(",")
-				.append(value.getMetadataField()).append(") : ");
+	private void report(StringBuilder reporter, Metadatum mt, String level, String... messages) {
+		reporter.append("- ").append(level).append(" (").append(mtFieldName).append(") : ");
 		for (String message : messages) {
 			reporter.append(message);
 		}
 		reporter.append("\n");
-
 	}
 
 	/**
@@ -250,9 +272,13 @@ public class MetadataAuthorityQualityControl extends AbstractCurationTask {
 	 * @param mf metadata field of the current metadata being processed
 	 * @return true if metadataToSkip array contains mf
 	 */
-	private boolean skipMetadata(MetadataField mf) {
+	private boolean skipMetadata(String mf) {
+		if (metadataToSkip == null) {
+			return false;
+		}
+
 		for (String dataToSkip : metadataToSkip) {
-			if (mf.toString().equals(dataToSkip)) {
+			if (mf.equals(dataToSkip)) {
 				return true;
 			}
 		}
@@ -260,19 +286,23 @@ public class MetadataAuthorityQualityControl extends AbstractCurationTask {
 	}
 
 	/**
-	 * Check if current metadata must be processed. If metadataToCheck is equals to "*",
-	 *  all authority controlled metadata can be processed
+	 * Check if current metadata must be processed. If metadataToCheck is equals to
+	 * "*", all authority controlled metadata can be processed
 	 *
 	 * @param mf metadata field of the current metadata being processed
 	 * @return true if metadataToCheck array contains mf or if metadataTocheck is
 	 *         empty
 	 */
-	private boolean isMetadataToCheck(MetadataField mf) {
+	private boolean isMetadataToCheck(String mf) {
+		if (metadataToCheck == null) {
+			return false;
+		}
+
 		if (metadataToCheck.length > 0 && metadataToCheck[0].equals("*")) {
 			return true;
 		}
 		for (String dataToCheck : metadataToCheck) {
-			if (mf.toString().equals(dataToCheck)) {
+			if (mf.equals(dataToCheck)) {
 				return true;
 			}
 		}

--- a/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/curation/MetadataAuthorityQualityControl.java
+++ b/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/curation/MetadataAuthorityQualityControl.java
@@ -1,0 +1,282 @@
+package ar.edu.unlp.sedici.dspace.curation;
+
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.Item;
+import org.dspace.content.MetadataField;
+import org.dspace.content.MetadataValue;
+import org.dspace.content.authority.ChoiceAuthorityManager;
+import org.dspace.content.authority.Choices;
+import org.dspace.content.authority.MetadataAuthorityManager;
+import org.dspace.curate.AbstractCurationTask;
+import org.dspace.curate.Curator;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Curation task that checks each authority controlled metadata of an item, reports anomalies and optionally fix them
+ *
+ */
+public class MetadataAuthorityQualityControl extends AbstractCurationTask {
+
+	private MetadataAuthorityManager authService = MetadataAuthorityManager.getManager();
+
+	private ChoiceAuthorityManager choiceAuthorityService = ChoiceAuthorityManager.getManager()();
+
+	/**
+	 * Configuration property. If true, curation task fixes the metadata errors by
+	 * itself. If false, only reports.
+	 */
+	private boolean fixmode = false;
+
+	/**
+	 * Configuration property, only works with fixmode in true.
+	 * If true, curation task also fixes metadata value variants.
+	 */
+	private boolean fixvariants = false;
+
+	/**
+	 * Configuration property, only works with fixmode in true.
+	 * If true, curation task also unsets every authority key
+	 * which is not connected with any authority.
+	 */
+	private boolean fixDangling = false;
+
+	/**
+	 * Configuration property, only works with fixmode in true.
+	 * If true, curation task also tries to find an authority key
+	 * for those metadata with a missing authority key.
+	 */
+	private boolean fixMissing = false;
+
+	/**
+	 * Configuration property. List of metadata_fields which are authority
+	 * controlled but we don't want the curation task to process
+	 */
+	private String[] metadataToSkip;
+
+	/**
+	 * Configuration property. List of metadata_fields that we want the curation
+	 * task process. If metadataToCheck = "*" then all authority controlled metadata
+	 * can be processed
+	 */
+	private String[] metadataToCheck;
+
+	@Override
+	public void init(Curator curator, String taskId) throws IOException {
+		super.init(curator, taskId);
+		fixmode = taskBooleanProperty("fixmode", false);
+		if (fixmode) {
+			fixvariants = taskBooleanProperty("fixVariants", false);
+			fixMissing = taskBooleanProperty("fixMissing", false);
+			fixDangling = taskBooleanProperty("fixDangling", false);
+		}
+		metadataToSkip = this.taskArrayProperty("skipMetadata");
+		metadataToCheck = this.taskArrayProperty("checkMetadata");
+	}
+
+	@Override
+	public int perform(DSpaceObject dso) throws IOException {
+		int status = Curator.CURATE_UNSET;
+		StringBuilder reporter = new StringBuilder();
+		if (dso instanceof Item) {
+			Item item = (Item) dso;
+			reporter.append("########## ");
+			reporter.append("Checking item with handle ").append(item.getHandle()).append(" and item id ")
+					.append(item.getID());
+			if (item.isWithdrawn()) {
+				reporter.append(" (WITHDRAWN)");
+			}
+			reporter.append(" ##########\n");
+			List<MetadataValue> mValues = itemService.getMetadata(item, Item.ANY, Item.ANY, Item.ANY, Item.ANY);
+			for (MetadataValue mv : mValues) {
+				//Only check metadata if it is authority controlled
+				if (authService.isAuthorityControlled(mv.getMetadataField()) && !skipMetadata(mv.getMetadataField())
+						&& isMetadataToCheck(mv.getMetadataField())) {
+					checkMetadataAuthority(reporter, mv, item);
+				}
+			}
+			report(reporter.toString());
+			status = Curator.CURATE_SUCCESS;
+		} else {
+			status = Curator.CURATE_SKIP;
+		}
+		setResult(reporter.toString());
+		return status;
+	}
+
+	private void checkMetadataAuthority(StringBuilder reporter, MetadataValue mv, Item item) {
+
+		if ((mv.getAuthority() == null || mv.getAuthority().isEmpty())
+				&& (mv.getValue() == null || mv.getValue().isEmpty())) {
+			report(reporter, mv, "ERROR", "Null both authority key and text_value");
+		} else if (mv.getAuthority() == null || mv.getAuthority().isEmpty()) {
+			checkMetadataWithoutAuthorityKey(reporter, mv, item);
+		} else {
+			checkMetadataWithAuthorityKey(reporter, mv);
+		}
+	}
+
+	/**
+	 * Reconciles metadata value with authority
+	 */
+	private void checkMetadataWithoutAuthorityKey(StringBuilder reporter, MetadataValue mv, Item item) {
+		//Null or empty authority, try to find one from the text_value
+		Choices choices = choiceAuthorityService.getBestMatch(mv.getMetadataField().toString(), mv.getValue(),
+				item.getOwningCollection(), mv.getLanguage());
+		if (authService.isAuthorityRequired(mv.getMetadataField())) {
+			report(reporter, mv, "ERROR", "Missing authority key for <<", mv.getValue(), ">>");
+		} else {
+			report(reporter, mv, "INFO", "Missing optional authority key for <<", mv.getValue(), ">>");
+		}
+		if (choices.values.length > 0) {
+			//Authority found from the text_value
+			String value = choices.values[0].value;
+			if (compare(value, mv.getValue())) {
+				//Exact match, new authority available
+				saveAuthorityKey(reporter, mv, choices);
+			} else {
+				// do not fix because can be either a false positive or variant
+				report(reporter, mv, "INFO", "Recommended value <<", choices.values[0].authority, ">> with confidence ",
+						String.valueOf(choices.confidence));
+			}
+		} else {
+			//Authority not found from the text_value, just check confidence
+			assertConfidenceNotFound(reporter, mv);
+		}
+
+	}
+
+	private void checkMetadataWithAuthorityKey(StringBuilder reporter, MetadataValue mv) {
+		String value = choiceAuthorityService.getLabel(mv.getMetadataField().toString(), mv.getAuthority(),
+				mv.getLanguage());
+		if (value == null || value.isEmpty()) {
+			// Authority not found
+			saveDanglingAuthority(reporter, mv);
+		} else if (compare(value, mv.getValue())) {
+			// Authority found, value==text_value
+			assertConfidenceUncertain(reporter, mv);
+		} else {
+			// Authority found, but value!=text_value
+			saveVariant(reporter, mv, value);
+		}
+	}
+
+	private void assertConfidenceUncertain(StringBuilder reporter, MetadataValue mv) {
+		if (mv.getConfidence() < Choices.CF_UNCERTAIN) {
+			report(reporter, mv, "ERROR", ": Invalid confidence ", String.valueOf(mv.getConfidence()), ", expected ",
+					String.valueOf(Choices.CF_UNCERTAIN));
+			if (fixmode) {
+				mv.setConfidence(Choices.CF_UNCERTAIN);
+				report(reporter, mv, "FIXED", "[CONFIDENCE] confidence replaced with value ",
+						String.valueOf(Choices.CF_UNCERTAIN));
+			}
+		}
+	}
+
+	private void assertConfidenceNotFound(StringBuilder reporter, MetadataValue mv) {
+		if (mv.getConfidence() > Choices.CF_NOTFOUND) {
+			report(reporter, mv, "ERROR", "Invalid confidence ", String.valueOf(mv.getConfidence()), ", expected ",
+					String.valueOf(Choices.CF_NOTFOUND));
+			if (fixmode) {
+				mv.setConfidence(Choices.CF_NOTFOUND);
+				report(reporter, mv, "FIXED", "[CONFIDENCE] confidence replaced with value ",
+						String.valueOf(Choices.CF_NOTFOUND));
+			}
+		}
+	}
+
+	private void saveVariant(StringBuilder reporter, MetadataValue mv, String value) {
+		report(reporter, mv, "WARN", "Variant found. Authority  <<", mv.getAuthority(),
+				">>; Metadata text_value <<", mv.getValue(), ">>; Authority value <<", value, ">>");
+		if (fixvariants) {
+			mv.setValue(value);
+			mv.setConfidence(Choices.CF_UNCERTAIN);
+			report(reporter, mv, "FIXED", "[VARIANT] variant replaced with authority's value.");
+		}
+
+	}
+
+	private void saveAuthorityKey(StringBuilder reporter, MetadataValue mv, Choices choices) {
+		String newAuthority = choices.values[0].authority;
+		report(reporter, mv, "INFO", "Found Authority <<", newAuthority, ">> for value <<", mv.getValue(), ">>.");
+		if (fixMissing && choices.confidence >= Choices.CF_UNCERTAIN) {
+			mv.setAuthority(newAuthority);
+			mv.setConfidence(choices.confidence);
+			report(reporter, mv, "FIXED", "[MISSING AUTHORITY] Authority set with value <<", newAuthority, ">>");
+		} else if (choices.confidence < Choices.CF_UNCERTAIN) {
+			report(reporter, mv, "NOT FIXED", "[AMBIGUOUS AUTHORITY] Authority key <<", newAuthority,
+					">> is ambiguous for text_value");
+		}
+
+	}
+
+	private void saveDanglingAuthority(StringBuilder reporter, MetadataValue mv) {
+		report(reporter, mv, "ERROR", "Authority key <<", mv.getAuthority(), ">> not found");
+		assertConfidenceNotFound(reporter, mv);
+		if (fixDangling) {
+			mv.setAuthority(null);
+			report(reporter, mv, "FIXED", "[DANGLING AUTHORITY] Authority set with NULL");
+			checkMetadataWithoutAuthorityKey(reporter, mv, (Item) mv.getResourceId());
+		}
+	}
+
+	private void report(StringBuilder reporter, MetadataValue value, String level, String... messages) {
+		reporter.append("- ").append(level).append(" (").append(value.getFieldId()).append(",")
+				.append(value.getMetadataField()).append(") : ");
+		for (String message : messages) {
+			reporter.append(message);
+		}
+		reporter.append("\n");
+
+	}
+
+	/**
+	 * Method used to compare 2 strings, considering several criteria
+	 *
+	 * @param value1
+	 * @param value2
+	 * @return true if value1.equals(value2) after some functions applied to both
+	 *         strings
+	 */
+	private boolean compare(String value1, String value2) {
+		String customValue1 = value1.trim();
+		String customValue2 = value2.trim();
+		return customValue1.equalsIgnoreCase(customValue2);
+	}
+
+	/**
+	 * Check if current metadata must not be processed.
+	 *
+	 * @param mf metadata field of the current metadata being processed
+	 * @return true if metadataToSkip array contains mf
+	 */
+	private boolean skipMetadata(MetadataField mf) {
+		for (String dataToSkip : metadataToSkip) {
+			if (mf.toString().equals(dataToSkip)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Check if current metadata must be processed. If metadataToCheck is equals to "*",
+	 *  all authority controlled metadata can be processed
+	 *
+	 * @param mf metadata field of the current metadata being processed
+	 * @return true if metadataToCheck array contains mf or if metadataTocheck is
+	 *         empty
+	 */
+	private boolean isMetadataToCheck(MetadataField mf) {
+		if (metadataToCheck.length > 0 && metadataToCheck[0].equals("*")) {
+			return true;
+		}
+		for (String dataToCheck : metadataToCheck) {
+			if (mf.toString().equals(dataToCheck)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+}


### PR DESCRIPTION
La cual chequea y eventualmente arregla la conexión de los metadatos controlados por autoridad con la autoridad conrrespondiente.

Hay que configurar las distintas alternativas en el archivo config/modules/metadataauthorityqualitycontrol.cfg
```bash
./install/bin/dspace curate -t metadataauthorityqualitycontrol -i 10915/27489 -r - > reporteCodigoRefactorizado.txt
```