### PR TITLE
-#4908 -#5644 Revisar expresiones modificadas en la detección de bots

### DIFF
--- a/dspace-api/src/main/java/org/dspace/statistics/SolrLogger.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/SolrLogger.java
@@ -886,10 +886,10 @@ public class SolrLogger
      * </p>
      */
     public static void markRobots() {
-        log.info("Marking robots by IP starting now...");
-        SolrLogger.markRobotsByIP();
         log.info("Marking robots by User Agent starting now...");
         SolrLogger.markRobotsByUserAgent();
+        log.info("Marking robots by IP starting now...");
+        SolrLogger.markRobotsByIP();
         log.info("Marking robots by Domain starting now...");
         SolrLogger.markRobotsByDomain();
     }
@@ -958,13 +958,13 @@ public class SolrLogger
      */
     public static void deleteRobots()
     {
-        log.info("Delete robots by IP starting now...");
-        for(String ip : SpiderDetector.getSpiderIpAddresses()){
-            deleteBy("ip:" + ip + "*");
-        }
         log.info("Delete robots by User Agent starting now...");
         for(String agent : SpiderDetector.getSpiderAgents()) {
             deleteBy("userAgent:/" + buildSolrRegex(agent) + "/");
+        }
+        log.info("Delete robots by IP starting now...");
+        for(String ip : SpiderDetector.getSpiderIpAddresses()){
+            deleteBy("ip:" + ip + "*");
         }
         log.info("Delete robots by Domain starting now...");
         for(String domain : SpiderDetector.getSpiderDomains()) {

--- a/dspace/config/modules/solr-statistics.cfg
+++ b/dspace/config/modules/solr-statistics.cfg
@@ -35,4 +35,4 @@ spiderips.urls = http://iplists.com/google.txt, \
 # Max Count of documents to process per page when marking bots with "stats-util" commandline. Defaults to 10.
 # This will affect the performance of the "./dspace stats-utils -m". If this number is too big, could raise OOM (OutOfMemory) 
 # exceptions; if the number is too small, then the command will take longer to execute.
-# spiderDetector.batchUpdateSize = 1000
+spiderDetector.batchUpdateSize = 10000

--- a/dspace/config/spiders/agents/COUNTER_Robots_list.txt
+++ b/dspace/config/spiders/agents/COUNTER_Robots_list.txt
@@ -13,11 +13,11 @@ AddThis
 A6\-Indexer
 ADmantX
 alexa
-Alexandria(\s|\+)prototype(\s|\+)project
+Alexandria(\ |\+)prototype(\ |\+)project
 AllenTrack
 almaden
 appie
-API[\ +]scraper
+API[\ \+]scraper
 Arachni
 Arachmo
 architext
@@ -34,7 +34,7 @@ biglotron
 BingPreview
 binlar
 bjaaland
-Blackboard[\ \s]Safeassign
+Blackboard[\ \+]Safeassign
 blaiz\-bee
 bloglines
 blogpulse
@@ -71,17 +71,17 @@ DeuSu\/
 Dispatch\/\d
 Docoloc
 docomo
-Download\ +Master
+Download[\ \+]Master
 DSurf
 DTS Agent
-EasyBib[\ \s]AutoCite[\ \s]
+EasyBib[\ \+]AutoCite[\ \+]
 easydl
 EBSCO\ EJS\ Content\ Server
 ELinks\/
 EmailSiphon
 EmailWolf
 Embedly
-EThOS\ \(British\ Library\)
+EThOS\+\(British\+Library\)
 facebookexternalhit\/
 favorg
 FDM(\ |\ +)[0-9]
@@ -90,7 +90,7 @@ feedburner
 FeedFetcher
 feedreader
 ferret
-Fetch(\ |\ +)API(\ |\ +)Request
+Fetch(\ |\+)API(\ |\+)Request
 findlinks
 findthatfile
 ^FileDown$
@@ -104,7 +104,7 @@ GetRight
 geturl
 G-i-g-a-b-o-t
 GLMSLinkAnalysis
-Goldfire(\ |\ +)Server
+Goldfire(\ |\+)Server
 google
 Grammarly
 grub
@@ -157,8 +157,8 @@ mail.ru
 MarcEdit.5.2.Web.Client
 mediapartners\-google
 megite
-MetaURI[\ +]API\/[0-9]\.[0-9]
-Microsoft(\ +)URL(\ |\ +)Control
+MetaURI[\ \+]API\/[0-9]\.[0-9]
+Microsoft(\ |\+)URL(\ |\+)Control
 Microsoft Office Existence Discovery
 Microsoft Office Protocol Discovery
 Microsoft-WebDAV-MiniRedir
@@ -189,7 +189,7 @@ nomad
 nutch
 ^oaDOI$
 ocelli
-Offline(\ |\ +)Navigator
+Offline(\ |\+)Navigator
 ^okhttp$
 onetszukaj
 ^Opera\/4$
@@ -203,7 +203,7 @@ PHP\/
 pioneer
 playmusic\.com
 playstarmusic\.com
-^Postgenomic(\ |\ +)v2
+^Postgenomic(\ |\+)v2
 powermarks
 proximic
 PycURL
@@ -234,9 +234,9 @@ sunrise
 Sysomos
 T\-H\-U\-N\-D\-E\-R\-S\-T\-O\-N\-E
 tailrank
-Teleport(\ |\ +)Pro
+Teleport(\ |\+)Pro
 Teoma
-The\ +Knowledge\ +AI
+The(\ |\+)Knowledge(\ |\+)AI
 titan
 ^Traackr\.com$
 Trove
@@ -256,7 +256,7 @@ voila
 voyager\/
 w3af.org
 Wanadoo
-Web(\ |\ +)Downloader
+Web(\ |\+)Downloader
 WebCloner
 webcollage
 WebCopier

--- a/dspace/config/spiders/agents/COUNTER_Robots_list.txt
+++ b/dspace/config/spiders/agents/COUNTER_Robots_list.txt
@@ -6,7 +6,7 @@ crawl
 ^IDA$
 ^ruby$
 ^voyager\/
-^@ozilla\/\d
+^@ozilla\/[0-9]
 ^脝脝陆芒潞贸碌脛$
 ^破解后的$
 AddThis
@@ -17,12 +17,12 @@ Alexandria(\s|\+)prototype(\s|\+)project
 AllenTrack
 almaden
 appie
-API[\+\s]scraper
+API[\ +]scraper
 Arachni
 Arachmo
 architext
 ArchiveTeam
-aria2\/\d
+aria2\/[0-9]
 arks
 ^Array$
 asterias
@@ -34,7 +34,7 @@ biglotron
 BingPreview
 binlar
 bjaaland
-Blackboard[\+\s]Safeassign
+Blackboard[\ \s]Safeassign
 blaiz\-bee
 bloglines
 blogpulse
@@ -48,10 +48,10 @@ celestial
 cfnetwork
 checklink
 checkprivacy
-China\sLocal\sBrowse\s2\.6
+China\ Local\ Browse\ 2\.6
 cloakDetect
 coccoc\/1\.0
-Code\sSample\sWeb\sClient
+Code\ Sample\ Web\ Client
 ColdFusion
 collection@infegy.com
 com\.plumanalytics
@@ -71,26 +71,26 @@ DeuSu\/
 Dispatch\/\d
 Docoloc
 docomo
-Download\+Master
+Download\ +Master
 DSurf
 DTS Agent
-EasyBib[\+\s]AutoCite[\+\s]
+EasyBib[\ \s]AutoCite[\ \s]
 easydl
-EBSCO\sEJS\sContent\sServer
+EBSCO\ EJS\ Content\ Server
 ELinks\/
 EmailSiphon
 EmailWolf
 Embedly
-EThOS\+\(British\+Library\)
+EThOS\ \(British\ Library\)
 facebookexternalhit\/
 favorg
-FDM(\s|\+)\d
+FDM(\ |\ +)[0-9]
 Feedbin
 feedburner
 FeedFetcher
 feedreader
 ferret
-Fetch(\s|\+)API(\s|\+)Request
+Fetch(\ |\ +)API(\ |\ +)Request
 findlinks
 findthatfile
 ^FileDown$
@@ -104,7 +104,7 @@ GetRight
 geturl
 G-i-g-a-b-o-t
 GLMSLinkAnalysis
-Goldfire(\s|\+)Server
+Goldfire(\ |\ +)Server
 google
 Grammarly
 grub
@@ -125,12 +125,12 @@ ichiro
 iktomi
 ilse
 Indy Library
-^integrity\/\d
+^integrity\/[0-9]
 internetseer
 intute
 iSiloX
 iskanie
-^java\/\d{1,2}.\d
+^Java\/[1-2]\.[0-9]
 jeeves
 jobo
 kyluka
@@ -157,8 +157,8 @@ mail.ru
 MarcEdit.5.2.Web.Client
 mediapartners\-google
 megite
-MetaURI[\+\s]API\/\d\.\d
-Microsoft(\s|\+)URL(\s|\+)Control
+MetaURI[\ +]API\/[0-9]\.[0-9]
+Microsoft(\ +)URL(\ |\ +)Control
 Microsoft Office Existence Discovery
 Microsoft Office Protocol Discovery
 Microsoft-WebDAV-MiniRedir
@@ -179,7 +179,7 @@ motor
 MuscatFerre
 myweb
 nagios
-^NetAnts\/\d
+^NetAnts\/[0-9]
 netcraft
 netluchs
 ng\/2\.
@@ -189,7 +189,7 @@ nomad
 nutch
 ^oaDOI$
 ocelli
-Offline(\s|\+)Navigator
+Offline(\ |\ +)Navigator
 ^okhttp$
 onetszukaj
 ^Opera\/4$
@@ -203,7 +203,7 @@ PHP\/
 pioneer
 playmusic\.com
 playstarmusic\.com
-^Postgenomic(\s|\+)v2
+^Postgenomic(\ |\ +)v2
 powermarks
 proximic
 PycURL
@@ -219,9 +219,9 @@ scan4mail
 scientificcommons
 scirus
 scooter
-Scrapy\/\d
+Scrapy\/[0-9]
 ScoutJet
-^scrutiny\/\d
+^scrutiny\/[0-9]
 SearchBloxIntra
 shoutcast
 SkypeUriPreview
@@ -234,9 +234,9 @@ sunrise
 Sysomos
 T\-H\-U\-N\-D\-E\-R\-S\-T\-O\-N\-E
 tailrank
-Teleport(\s|\+)Pro
+Teleport(\ |\ +)Pro
 Teoma
-The\+Knowledge\+AI
+The\ +Knowledge\ +AI
 titan
 ^Traackr\.com$
 Trove
@@ -256,7 +256,7 @@ voila
 voyager\/
 w3af.org
 Wanadoo
-Web(\s|\+)Downloader
+Web(\ |\ +)Downloader
 WebCloner
 webcollage
 WebCopier
@@ -278,6 +278,6 @@ y!j
 yacy
 yahoo
 yandex
-Yeti\/\d
+Yeti\/[0-9]
 zeus
 zyborg

--- a/dspace/config/spiders/agents/COUNTER_Robots_list.txt
+++ b/dspace/config/spiders/agents/COUNTER_Robots_list.txt
@@ -6,7 +6,7 @@ crawl
 ^IDA$
 ^ruby$
 ^voyager\/
-^@ozilla\/[0-9]
+^\@ozilla\/[0-9]
 ^脝脝陆芒潞贸碌脛$
 ^破解后的$
 AddThis

--- a/dspace/config/spiders/agents/COUNTER_Robots_list.txt
+++ b/dspace/config/spiders/agents/COUNTER_Robots_list.txt
@@ -18,6 +18,7 @@ AllenTrack
 almaden
 appie
 API[\+\s]scraper
+Arachni
 Arachmo
 architext
 ArchiveTeam
@@ -84,6 +85,7 @@ EThOS\+\(British\+Library\)
 facebookexternalhit\/
 favorg
 FDM(\s|\+)\d
+Feedbin
 feedburner
 FeedFetcher
 feedreader
@@ -150,7 +152,7 @@ LOCKSS
 LongURL.API
 ltx71
 lwp
-lycos[\_\+]
+lycos[_+]
 mail.ru
 MarcEdit.5.2.Web.Client
 mediapartners\-google
@@ -218,6 +220,7 @@ scientificcommons
 scirus
 scooter
 Scrapy\/\d
+ScoutJet
 ^scrutiny\/\d
 SearchBloxIntra
 shoutcast
@@ -275,5 +278,6 @@ y!j
 yacy
 yahoo
 yandex
+Yeti\/\d
 zeus
 zyborg

--- a/dspace/config/spiders/agents/example
+++ b/dspace/config/spiders/agents/example
@@ -1,42 +1,42 @@
 Mozilla\/5\.0 \(compatible; PRTG Network Monitor \(www\.paessler\.com\); Windows\)
 Mozilla\/5\.0 \(compatible; monitis \- premium monitoring service; http:\/\/www\.monitis\.com\)
 Pingdom\.com_bot_version_1\.4_\(http:\/\/www\.pingdom\.com\/\)
-Alexandria(\s|\+)prototype(\s|\+)project
+Alexandria(\ |\ +)prototype(\ |\ +)project
 AllenTrack
 Arachmo
 Brutus\/AET
-China\sLocal\sBrowse\s2\.6
-Code\sSample\sWeb\sClient
+China\ Local\ Browse\ 2\.6
+Code\ Sample\ Web\ Client
 ContentSmartz
 DSurf
 DataCha0s\/2\.0
-Demo\sBot
+Demo\ Bot
 EmailSiphon
 EmailWolf
-FDM(\s|\+)1
-Fetch(\s|\+)API(\s|\+)Request
+FDM(\ |\ +)1
+Fetch(\ |\ +)API(\ |\ +)Request
 GetRight
-Goldfire(\s|\+)Server
+Goldfire(\ |\ +)Server
 Googlebot
 HTTrack
 LOCKSS
 LWP\:\:Simple
 MSNBot
-Microsoft(\s|\+)URL(\s|\+)Control
+Microsoft(\ |\ +)URL(\ |\ +)Control
 Milbot
 MuscatFerre
 NABOT
 NaverBot
-Offline(\s|\+)Navigator
+Offline(\ |\ +)Navigator
 OurBrowser
 Python\-urllib
 Readpaper
 Strider
 T\-H\-U\-N\-D\-E\-R\-S\-T\-O\-N\-E
-Teleport(\s|\+)Pro
+Teleport(\ |\ +)Pro
 Teoma
 Wanadoo
-Web(\s|\+)Downloader
+Web(\ |\ +)Downloader
 WebCloner
 WebCopier
 WebReaper
@@ -45,8 +45,8 @@ WebZIP
 Webinator
 Webmetrics
 Wget
-Xenu(\s|\+)Link(\s|\+)Sleuth
-#[+:,\.\;\/\\-]bot
+Xenu(\ |\ +)Link(\ |\ +)Sleuth
+#[+\:,\.\;\/\\\-]bot
 [^a]fish
 ^voyager\/
 acme\.spider
@@ -71,7 +71,7 @@ blogpulse
 boitho\.com\-dc
 bookmark\-manager
 bot
-#bot[+:,\.\;\/\\-]
+#bot[+\:,\.\;\/\\\-]
 bspider
 bwh3_user_agent
 celestial

--- a/dspace/config/spiders/agents/example
+++ b/dspace/config/spiders/agents/example
@@ -1,7 +1,7 @@
 Mozilla\/5\.0 \(compatible; PRTG Network Monitor \(www\.paessler\.com\); Windows\)
 Mozilla\/5\.0 \(compatible; monitis \- premium monitoring service; http:\/\/www\.monitis\.com\)
 Pingdom\.com_bot_version_1\.4_\(http:\/\/www\.pingdom\.com\/\)
-Alexandria(\ |\ +)prototype(\ |\ +)project
+Alexandria(\ |\+)prototype(\ |\+)project
 AllenTrack
 Arachmo
 Brutus\/AET
@@ -13,30 +13,30 @@ DataCha0s\/2\.0
 Demo\ Bot
 EmailSiphon
 EmailWolf
-FDM(\ |\ +)1
-Fetch(\ |\ +)API(\ |\ +)Request
+FDM(\ |\+)1
+Fetch(\ |\+)API(\ |\+)Request
 GetRight
-Goldfire(\ |\ +)Server
+Goldfire(\ |\+)Server
 Googlebot
 HTTrack
 LOCKSS
 LWP\:\:Simple
 MSNBot
-Microsoft(\ |\ +)URL(\ |\ +)Control
+Microsoft(\ |\+)URL(\ |\+)Control
 Milbot
 MuscatFerre
 NABOT
 NaverBot
-Offline(\ |\ +)Navigator
+Offline(\ |\+)Navigator
 OurBrowser
 Python\-urllib
 Readpaper
 Strider
 T\-H\-U\-N\-D\-E\-R\-S\-T\-O\-N\-E
-Teleport(\ |\ +)Pro
+Teleport(\ |\+)Pro
 Teoma
 Wanadoo
-Web(\ |\ +)Downloader
+Web(\ |\+)Downloader
 WebCloner
 WebCopier
 WebReaper
@@ -45,7 +45,7 @@ WebZIP
 Webinator
 Webmetrics
 Wget
-Xenu(\ |\ +)Link(\ |\ +)Sleuth
+Xenu(\ |\+)Link(\ |\+)Sleuth
 #[+\:,\.\;\/\\\-]bot
 [^a]fish
 ^voyager\/

--- a/dspace/config/spiders/agents/sedici_useragents
+++ b/dspace/config/spiders/agents/sedici_useragents
@@ -11,3 +11,31 @@ MauiBot
 ltx71
 Applebot
 BUbiNG
+BLEXBot
+archive.org_bot
+Twitterbot
+Blekkobot
+BDCbot
+TurnitinBot
+trendictionbot
+crawler4j
+SISTRIX Crawler
+ezooms\.bot
+wotbox
+linkdexbot\/2\.2
+Cliqzbot
+Vegi bot
+Goibot
+Barkrowler
+SEOkicks-Robot
+OpenLinkProfiler\.org\/bot
+SemrushBot
+Linguee Bot
+GarlikCrawler
+Go-http-client\/1\.1
+Apache-HttpClient\/4\.1\.3
+GrapeshotCrawler
+GrapeshotCrawler\/2\.0
+studylib download bot
+Altmetribot
+WBSearchBot\/1\.1


### PR DESCRIPTION
Hay que revisar las nuevas expresiones mantenidas por COUNTER, luego se agregaron algunas detectadas en nuestro core statistics (en el archivo "spiders/agents/sedici_useragents").

Por ultimo, se cambió el criterio en el orden de ejecución del marcado y eliminado de bots:
1. Marcado/Eliminado por **userAgent**.
2. Marcado/Eliminado por **ip**.
3. Marcado/Eliminado por **dns**.