### PR TITLE
-#5688 Se agregó una "whitelist" hardcodeada en GoogleScholar metadata

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/GoogleMetadata.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/GoogleMetadata.java
@@ -1093,6 +1093,7 @@ public class GoogleMetadata
 		boolean result = false;
 		try {
             result = AuthorizeManager.authorizeActionBoolean(ourContext, bitstream, Constants.READ, true)
+                    //SEDICI-Ticket#5688
                     && priorityList.contains(bitstream.getFormat().getShortDescription());
 		} catch (SQLException e) {
 			log.error("Cannot determine whether bitstream is public, assuming it isn't. bitstream_id=" + bitstream.getID(), e);

--- a/dspace-api/src/main/java/org/dspace/app/util/GoogleMetadata.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/GoogleMetadata.java
@@ -126,6 +126,9 @@ public class GoogleMetadata
     private static final int MULTI = 1;
 
     private static final int ALL_FIELDS_IN_OPTION = 2;
+    
+    private static final ArrayList<String> priorityList = new ArrayList<String>(Arrays.asList(
+            "Adobe PDF", "Postscript", "Microsoft Word XML", "Microsoft Word", "RTF", "EPUB"));
 
     private Context ourContext;
     // Load configured fields from google-metadata.properties
@@ -1089,7 +1092,8 @@ public class GoogleMetadata
 		}
 		boolean result = false;
 		try {
-            result = AuthorizeManager.authorizeActionBoolean(ourContext, bitstream, Constants.READ, true);
+            result = AuthorizeManager.authorizeActionBoolean(ourContext, bitstream, Constants.READ, true)
+                    && priorityList.contains(bitstream.getFormat().getShortDescription());
 		} catch (SQLException e) {
 			log.error("Cannot determine whether bitstream is public, assuming it isn't. bitstream_id=" + bitstream.getID(), e);
 		}


### PR DESCRIPTION
Utilizada para determinar qué formato de bitstreams son válidos unicamente para crear el metadato `citation_pdf_url`. De esta manera se busca evitar situaciones erróneas, como poner en el metadato
`citation_pdf_url` una referencia a un bitstream de tipo audio.

### Ejemplos
Antes de los cambios introducidos, dado el item en http://sedici.unlp.edu.ar/handle/10915/20896 que tiene como 'primary bitstream' un JPG, el "citation_pdf_url" creado es el siguiente:
```
<meta content="http://sedici.unlp.edu.ar/bitstream/handle/10915/20896/Tapa.pdf?sequence=2" name="citation_pdf_url" />
```
Los cambios agregados evita esta situación, e imprime como "citation_pdf_url" alguno válido de la "whitelist" hardcodeada, para este caso se creó el siguiente citation:
``` 
<meta content="http://sedici.unlp.edu.ar/bitstream/handle/10915/20896/Digesto_de_la_UNLP.pdf?sequence=3" name="citation_pdf_url" />
```
-----------

Para el caso de este item http://sedici.unlp.edu.ar/handle/10915/25944, que solamente tiene un bitstream que no es PDF (y también está marcado como 'primary'), antes de los cambios, el "citation_pdf_url" generado es el siguiente:

<meta content="http://sedici.unlp.edu.ar/bitstream/handle/10915/25944/Track_3__01_34_.pdf?sequence=1" name="citation_pdf_url" />

Los cambios agregados evitan la impresión del metadato "citation_pdf_url" para este archivo de audio.

### Aclaraciones
El comportamiento de seguir agregando la extensión **".pdf"** a cualquier bitstream todavía sigue vigente. Por ejemplo, si el item tiene un .doc como único bitstream, y dado que es un formato válido para scholar, entonces se imprimirá el metadato `citation_pdf_url` con la extensión **archivo_DOC.pdf**, en vez de **archivo_DOC.doc**.  