### PR TITLE
Chequeo del estado de un envío de metadatos relativos a un DOI en la Submission Queue de Crossref 

### DIFF
--- a/dspace/config/spring/api/identifier-service.xml
+++ b/dspace/config/spring/api/identifier-service.xml
@@ -127,6 +127,10 @@
         <property name='CROSSREF_QUERY_PATH' value='/servlet/query' />
         <property name="DEPOSIT_PREFIX_FILENAME" value="sedici" />
         <property name='disseminationCrosswalkName' value="Crossref" />
+        <!-- Indicate how many milliseconds the connector must wait polling the submission queue. Defaults to 1 minute (60000 millis). -->
+        <property name='submission_query_timeout' value='120000' />
+        <!-- Indicate interval time in milliseconds between every polling over submission queue. Defaults to 1000 millis. -->
+        <property name='submission_query_interval' value='2000' />
     </bean>
 
 </beans>

--- a/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/identifier/doi/CrossrefHelper.java
+++ b/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/identifier/doi/CrossrefHelper.java
@@ -1,0 +1,120 @@
+package ar.edu.unlp.sedici.dspace.identifier.doi;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jdom.Attribute;
+import org.jdom.Document;
+import org.jdom.Element;
+import org.jdom.JDOMException;
+import org.jdom.input.SAXBuilder;
+import org.jdom.xpath.XPath;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CrossrefHelper {
+
+    private static final Logger log = LoggerFactory.getLogger(CrossrefHelper.class);
+
+    /**
+     * Please use the {@code getElementsFromPath} instead this, unless necessary.
+     * Get all nodes objects within XML data tied to the specified XPATH expression.
+     * @return a list of all nodes objects tied to XPATH or @null if the XPATH does not match.
+     */
+    public static List<?> getNodesFromPath(Element root, String xpath_expression, String ns_prefix, String ns_uri) {
+        List<?> targetNodes = null;
+        XPath xpathDOI;
+        Document doc;
+        try {
+            xpathDOI = XPath.newInstance(xpath_expression);
+            xpathDOI.addNamespace(ns_prefix, ns_uri);
+            if(root.getDocument() != null) {
+                doc = root.getDocument();
+            } else {
+                doc = new Document(root);
+            }
+            targetNodes = xpathDOI.selectNodes(doc);
+        } catch (JDOMException e) {
+            log.error("Incorrect XPATH expression!! Please check it. (XPATH =" + xpath_expression  + ")",  e.getMessage());
+            //continue the normal code and return @null if this excepcion is raised...
+        }
+        return targetNodes;
+    }
+
+    /**
+     * Get an Element node object within XML data tied to the specified XPATH expression.
+     */
+    public static List<Element> getElementsFromPath(Element root, String xpath_expression, String ns_prefix, String ns_uri) {
+        List<?> nodes = getNodesFromPath(root, xpath_expression, ns_prefix, ns_uri);
+        if (nodes == null || nodes.isEmpty()) {
+            return null;
+        }
+        List<Element> elements = new ArrayList<Element>();
+        for (Object node : nodes) {
+            elements.add((Element) node);
+        }
+        return elements;
+    }
+
+    /**
+     * Get an Element node object within XML data tied to the specified XPATH expression.
+     */
+    public static Element getElementFromPath(Element root, String xpath_expression, String ns_prefix, String ns_uri) {
+        Element element = null;
+        List<?> nodes = getNodesFromPath(root, xpath_expression, ns_prefix, ns_uri);
+        if(nodes != null && !nodes.isEmpty()) {
+            element = (Element)(nodes.get(0));
+        }
+        return element;
+    }
+
+    /**
+     * Get an Attribute node object within XML data tied to the specified XPATH expression.
+     */
+    public static Attribute getAttributeFromPath(Element root, String xpath_expression, String ns_prefix, String ns_uri) {
+        Attribute attribute = null;
+        List<?> nodes = getNodesFromPath(root, xpath_expression, ns_prefix, ns_uri);
+        if(nodes != null && !nodes.isEmpty()) {
+            attribute = (Attribute)(nodes.get(0));
+        }
+        return attribute;
+    }
+    
+    /**
+     * Get an Element within XML data tied to the specified XPATH expression. The namespace URI and prefix are considered empty.
+     * @return the Element node object tied to XPATH or @null if the XPATH does not match.
+     */
+    public static Element getElementFromPath(Element root, String xpath_expression) {
+        return getElementFromPath(root, xpath_expression, "", "");
+    }
+    /**
+     * Get an Attribute within XML data tied to the specified XPATH expression. The namespace URI and prefix are considered empty.
+     * @return the Attribute node object tied to XPATH or @null if the XPATH does not match.
+     */
+    public static Attribute getAttributeFromPath(Element root, String xpath_expression) {
+        return getAttributeFromPath(root, xpath_expression, "", "");
+    }
+    
+
+    /**
+     * Convert a target String in XML format to an JDom Documento object.
+     * @param XMLString     the String to convert
+     * @return a Document based on XMLString parameter content. Return null in case of empty or null for XMLString.
+     * @throws JDOMException     when cannot parse XMLString
+     */
+    public static Document parseXMLContent(String XMLString) throws JDOMException {
+        if (XMLString == null){
+            return null;
+        }
+        try {
+            SAXBuilder builder = new SAXBuilder();
+            InputStream stream = new ByteArrayInputStream(XMLString.getBytes("UTF-8"));
+            return builder.build(stream);
+        } catch (IOException e) {
+            throw new RuntimeException("Got an IOException while reading from a string?!", e);
+        }
+    }
+}

--- a/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/identifier/doi/CrossrefHelper.java
+++ b/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/identifier/doi/CrossrefHelper.java
@@ -4,7 +4,9 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.jdom.Attribute;
 import org.jdom.Document;
@@ -115,6 +117,60 @@ public class CrossrefHelper {
             return builder.build(stream);
         } catch (IOException e) {
             throw new RuntimeException("Got an IOException while reading from a string?!", e);
+        }
+    }
+    
+    public static Timer createTimer(long millisTimeout, long millisDelay) {
+        CrossrefHelper helper = new CrossrefHelper();
+        Timer timer = helper.new Timer(millisTimeout, millisDelay);
+        return timer;
+    }
+    
+    public static void makeDelay(long milliseconds) {
+        try {
+            TimeUnit.MILLISECONDS.sleep(milliseconds);
+        } catch (InterruptedException e) {
+            log.warn("Some error happens when sleeping "+ milliseconds +" milliseconds at CrossrefHelper...");
+        }
+    }
+    
+    protected class Timer{
+        long millisTimeout;
+        long millisDelay;
+        Calendar initialTime;
+        Calendar timeOut;
+        
+        protected Timer(long millisTimeout, long millisDelay){
+            this.millisTimeout = millisTimeout;
+            this.millisDelay = millisDelay;
+            this.initialTime = Calendar.getInstance();
+            this.timeOut = Calendar.getInstance();
+            this.timeOut.setTimeInMillis(initialTime.getTimeInMillis() + millisTimeout);
+        }
+        /**
+         * Check if the timeout is finish.
+         * @return true if timeout has been reach.
+         */
+        protected boolean isTimedOut() {
+            return (getRemainingTimeout() <= 0);
+        }
+        
+        /**
+         * Sleep the timer for a while, according on the delay in milliseconds configured.
+         * @throws InterruptedException 
+         */
+        protected void delay() throws InterruptedException{
+            long finalDelay = millisDelay;
+            long remainingTimeout = getRemainingTimeout();
+            if(remainingTimeout < finalDelay) {
+                finalDelay = remainingTimeout;
+            }
+            //sleep
+            TimeUnit.MILLISECONDS.sleep(finalDelay);
+        }
+        
+        long getRemainingTimeout() {
+            return timeOut.getTimeInMillis() - Calendar.getInstance().getTimeInMillis();
         }
     }
 }


### PR DESCRIPTION
Luego de enviar en un archivo XML los metadatos respectivos a un DOI a Crossref (mediante el endpoint _"/deposit"_), tanto para la acción de _registración_ o de _actualización_ de metadatos, Crossref inicia un proceso de validación de ese archivo (en la llamada _"Submission Queue"_). Esta validación determina si los metadatos correspondiente al DOI son correctos o no. y puede consultarse a través del endpoint _"/submissionDownload"_. 

El problema es que, según la [documentación](https://support.crossref.org/hc/en-us/articles/215956603-Submission-Queue), esta etapa de procesamiento puede tardar varios minutos,  dependiendo del estado de carga de la Submission Queue. Por esto, para determinar si un DOI fue procesado exitosamente, puede que haya que quedarse en un bucle de espera hasta su procesamiento efectivo.

-------------------

En este PR se incluyen los siguientes **cambios**:
1. Se agregó un valor de "timeout" para determinar cuánto tiempo el CrossrefConnector debe estar preguntando el resultado de depósito de un DOI (tanto para REGISTRACIÓN como para ACTUALIZACIÓN).

    * Se agregaron las propiedades de timeout en el identifier-service.xml.
```xml
<!-- Indicate how many milliseconds the connector must wait polling the submission queue. Defaults to 1 minute (60000 millis). -->
<property name='submission_query_timeout' value='120000' />
<!-- Indicate interval time in milliseconds between every polling over submission queue. Defaults to 1000 millis. -->
<property name='submission_query_interval' value='2000' />
```
2. Se extrajo código del connector a una clase helper (_CrossrefHelper_).
3. Cambios en los nombres de archivos subidos a Crossref (a ruta "/deposit", para REGISTRACIÓN como para ACTUALIZACIÓN).

    * Ahora, durante la _REGISTRACIÓN_ de metadatos de un item en Crossref, solamente se generará un único archivo en la submission queue ( p.e. con la forma "sedici_10.35537_10915_68085_registration.xml"). Si se intenta registrar dos veces un mismo ítem, el connector detecta el submission file inicial y evita el envío nuevamente.

    * Ahora, durante la _ACTUALIZACIÓN_ de metadatos de un ítem en Crossref, se generará un archivo en la submission queue por cada "última actualización" de un ítem en DSpace, diferenciándolos univocamente (p.e. si un item se actualizó en la fecha 19-08-26T18:00:06.307Z, se generará un único archivo correspondiente llamado "sedici_10.35537_10915_68085_update_19-08-26_180006.307.xml"; si posteriormente se actualiza el ítem, entonces se generará otro archivo con el nombre "sedici_10.35537_10915_68085_update_19-08-27_110313.386.xml").