### PR TITLE
 -#5997 Ajusto el mapeo a Crossref para usar sedici.identifier.other en vez de sedici.identifier.doi

### DIFF
--- a/dspace/config/crosswalks/DIM2Crossref.xsl
+++ b/dspace/config/crosswalks/DIM2Crossref.xsl
@@ -824,11 +824,13 @@
 		<doi_data xmlns="http://www.crossref.org/schema/4.4.2">
 
 			<doi>
-				<!-- Solo seteo el doi si ya existe alguno en sedici.identifier.doi, sino se setea uno nuevo despúes, por afuera del xsl -->
+				<!-- Solo seteo el doi si ya existe alguno en sedici.identifier.other, sino se setea uno nuevo despúes, por afuera del xsl -->
 				<xsl:if
-				test="dspace:field[@mdschema='sedici' and @element='identifier' and @qualifier='doi' and contains(., '10.')]">
+					test="dspace:field[@mdschema='sedici' and @element='identifier' and @qualifier='other'
+						and java:ar.edu.unlp.sedici.dspace.utils.Utils.isDoi(text())]">
 					<xsl:variable name="doi"
-					select="dspace:field[@mdschema='sedici' and @element='identifier' and @qualifier='doi']" />
+					select="dspace:field[@mdschema='sedici' and @element='identifier' and @qualifier='other'
+						and java:ar.edu.unlp.sedici.dspace.utils.Utils.isDoi(text())]" />
 					<xsl:variable name="doiStartIndex"
 					select="string-length(substring-before($doi,'10.'))+1" />
 					<xsl:value-of select="substring($doi,$doiStartIndex)" />

--- a/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/utils/Utils.java
+++ b/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/utils/Utils.java
@@ -10,6 +10,7 @@ import org.dspace.storage.rdbms.DatabaseManager;
 import org.dspace.storage.rdbms.TableRow;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.dspace.identifier.DOI;
 
 public class Utils {
 	
@@ -59,6 +60,16 @@ public class Utils {
 
 	public static boolean matchRegex(String text, String regex) {
 		return java.util.regex.Pattern.matches(regex, text);
+	}
+
+	/*
+	 * Devuelve verdadero si el string cumple con el formato de doi.
+	 * Es decir, si cumple con algunos de los formatos siguientes:
+	 * http(s)://doi.org/10.XXXX/XXXX,http(s)://dx.doi.org/10.XXXX/XXXX o doi:10.XXXX/XXXX
+	 */
+	public static boolean isDoi(String identifier) {
+		String doiRegex = "((https?:\\/\\/(dx\\.)?doi.org\\/)|(doi:))10\\.[0-9]{4,9}\\/.{1,200}";
+		return java.util.regex.Pattern.matches(doiRegex, identifier);
 	}
 
 }


### PR DESCRIPTION
Ahora el chequeo de si el item ya tenía doi se hace a través del metadato sedici.identifier.other y no con sedici.identifier.doi ya que este ultimo metadato va a ser eliminado.
Por lo que si el item tiene algun doi asignado en el campo sedici.identifier.other, entonces ese doi se mapea en el campo <doi_data><doi> de Crossref
Para asegurarme si identifier.other tiene realmente un doi hago un chequeo usando regex. Para eso creé el metodo isDoi(string) en la clase Utils el cual chequea que el metadato cumpla con algunos de los formatos siguientes: http(s)://doi.org/10.XXXX/XXXX,http(s)://dx.doi.org/10.XXXX/XXXX o doi:10.XXXX/XXXX