### PR TITLE
-#6001 Ahora se puede realizar la actualización de items en crossref en tanda, desde consola.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/identifier/doi/DOIOrganiser.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/doi/DOIOrganiser.java
@@ -362,29 +362,30 @@ public class DOIOrganiser {
         
         if(line.hasOption("update-doi"))
         {
-            String identifier = line.getOptionValue("update-doi");
+            String identifiers = line.getOptionValue("update-doi");
             
-            if(null == identifier)
+            if(null == identifiers)
             {
                 helpformater.printHelp("\nDOI organiser\n", options);
             }
             else
             {
-                try {
-                    TableRow doiRow = organiser.findTableRow(identifier);
-                    DSpaceObject dso = DSpaceObject.find(
-                            context, 
-                            doiRow.getIntColumn("resource_type_id"), 
-                            doiRow.getIntColumn("resource_id"));
-                    organiser.update(doiRow, dso);
-                } catch (SQLException ex) {
-                    LOG.error(ex);
-                } catch (IllegalArgumentException ex) {
-                    LOG.error(ex);
-                } catch (IllegalStateException ex) {
-                    LOG.error(ex);
-                } catch (IdentifierException ex) {
-                    LOG.error(ex);
+                String[] identifiersList = identifiers.split(",");
+                for (String identifier: identifiersList) {
+                    try {
+                        if (!line.hasOption('q')) {
+                            System.out.println("Registering identifier " + identifier);
+                        }
+                        TableRow doiRow = organiser.findTableRow(identifier.trim());
+                        DSpaceObject dso = DSpaceObject.find(
+                                context,
+                                doiRow.getIntColumn("resource_type_id"),
+                                doiRow.getIntColumn("resource_id"));
+                        organiser.update(doiRow, dso);
+                    } catch (Exception ex) {
+                        LOG.error(ex);
+                        ex.printStackTrace(System.err);
+                    }
                 }
             }
         }
@@ -704,13 +705,10 @@ public class DOIOrganiser {
                     + doiIdentifierException
                         .codeToString(doiIdentifierException.getCode()), ex);
            
-            if(!quiet)
-            {
-                System.err.println("It wasn't possible to update this identifier: " 
-                                 + DOI.SCHEME + doiRow.getStringColumn("doi"));
-            }
-            
-        } 
+            System.err.println("It wasn't possible to update this identifier: "
+                             + DOI.SCHEME + doiRow.getStringColumn("doi"));
+            ex.printStackTrace(System.err);
+        }
         catch (IllegalArgumentException ex) 
         {
             LOG.error("Database table DOI contains a DOI that is not valid: "
@@ -720,6 +718,7 @@ public class DOIOrganiser {
             {
                 System.err.println("It wasn't possible to update this identifier: " 
                                  + DOI.SCHEME + doiRow.getStringColumn("doi"));
+                ex.printStackTrace(System.err);
             }
              
             throw new IllegalStateException("Database table DOI contains a DOI "


### PR DESCRIPTION
Al igual que se hace para el register de items en crossref, se debe pasar como parámetro en el comando doi-organizer --update-doi una lista de identificadores (DOI, handle o ItemID) separados por coma, ej:
./dspace doi-organiser --update-doi handle1,handle2,ItemID3