### PR TITLE
Ticket#5676 Arreglo authorities que no se validan al instanciarse una plantilla

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/WorkspaceItem.java
+++ b/dspace-api/src/main/java/org/dspace/content/WorkspaceItem.java
@@ -199,8 +199,16 @@ public class WorkspaceItem implements InProgressSubmission
 
             for (int n = 0; n < md.length; n++)
             {
-                item.addMetadata(md[n].schema, md[n].element, md[n].qualifier, md[n].language,
-                        md[n].value);
+                if (md[n].authority != null && !md[n].authority.isEmpty())
+                {
+                    item.addMetadata(md[n].schema, md[n].element, md[n].qualifier, md[n].language,
+                            md[n].value, md[n].authority, md[n].confidence);
+                }
+                else
+                {
+                    item.addMetadata(md[n].schema, md[n].element, md[n].qualifier, md[n].language,
+                            md[n].value);
+                }
             }
         }
 

--- a/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/xsl/aspect/general/choice-authority-control.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/xsl/aspect/general/choice-authority-control.xsl
@@ -419,11 +419,11 @@ No redefino todos los templates, solo los que necesito redefinir.
 
 	  <xsl:choose>
 
-	  	<xsl:when test="$confidence='accepted'">
+		<xsl:when test="$confidence='accepted' or $confidence='uncertain'">
 	  	  <xsl:choose>
-	  	  <xsl:when test="$authLabel = $value">
+			<xsl:when test="normalize-space($authLabel) = normalize-space($value)">
 			 <xsl:call-template name="authorityConfidenceIcon">
-                <xsl:with-param name="confidence">accepted</xsl:with-param>
+				<xsl:with-param name="confidence" select="$confidence" />
                 <xsl:with-param name="id" select="$confidenceIndicatorID"/>
              </xsl:call-template>
 			</xsl:when>	


### PR DESCRIPTION
Ahora cuando se instancia una plantilla en el submission, se mantienen las autoridades seteadas en las plantillas (si es que existe) en vez de hacer un lookup a la base de autoridades a partir del value del metadato.

También al comparar el value del metadato con el label de la autoridad se le hace un trim()  los valores antes de realizar la comparación.

Y para el confidence se tiene en cuenta que su valor venga en 500 o 'uncertain'.