### PR TITLE
-#2527 Agrego la posibilidad de exportar autores de más de un tipo de metadato en el feed

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/SyndicationFeed.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/SyndicationFeed.java
@@ -101,8 +101,8 @@ public class SyndicationFeed
     private static String descriptionFields[] =
         getDefaultedConfiguration("webui.feed.item.description", defaultDescriptionFields).split("\\s*,\\s*");
 
-    private static String authorField =
-        getDefaultedConfiguration("webui.feed.item.author", defaultAuthorField);
+    private static String authorFields[] =
+        getDefaultedConfiguration("webui.feed.item.author", defaultAuthorField).split("\\s*,\\s*");
 
     // metadata field for Podcast external media source url
     private static String externalSourceField = getDefaultedConfiguration("webui.feed.podcast.sourceuri", defaultExternalMedia);
@@ -299,16 +299,20 @@ public class SyndicationFeed
                 }
 
                 // This gets the authors into an ATOM feed
-                Metadatum authors[] = item.getMetadataByMetadataString(authorField);
-                if (authors.length > 0)
-                {
-                    List<SyndPerson> creators = new ArrayList<SyndPerson>();
-                    for (Metadatum author : authors)
+                List<SyndPerson> creators = new ArrayList<SyndPerson>();
+                for (String authorField : authorFields) {
+                    Metadatum authors[] = item.getMetadataByMetadataString(authorField);
+                    if (authors.length > 0)
                     {
-                        SyndPerson sp = new SyndPersonImpl();
-                        sp.setName(author.value);
-                        creators.add(sp);
+                        for (Metadatum author : authors)
+                        {
+                            SyndPerson sp = new SyndPersonImpl();
+                            sp.setName(author.value);
+                            creators.add(sp);
+                        }
                     }
+                }
+                if (creators.size() > 0) {
                     entry.setAuthors(creators);
                 }
 
@@ -322,12 +326,12 @@ public class SyndicationFeed
                         Metadatum dcAuthors[] = item.getMetadataByMetadataString(dcCreatorField);
                         if (dcAuthors.length > 0)
                         {
-                            List<String> creators = new ArrayList<String>();
+                            List<String> dcCreators = new ArrayList<String>();
                             for (Metadatum author : dcAuthors)
                             {
-                                creators.add(author.value);
+                                dcCreators.add(author.value);
                             }
-                            dc.setCreators(creators);
+                            dc.setCreators(dcCreators);
                         }
                     }
                     if (dcDateField != null && !hasDate)
@@ -403,7 +407,7 @@ public class SyndicationFeed
                     // Get iTunes specific fields: author, subtitle, summary, duration, keywords
                     EntryInformation itunes = new EntryInformationImpl();
 
-                    String author = getOneDC(item, authorField);
+                    String author = getOneDC(item, authorFields[0]);
                     if (author != null && author.length() > 0) {
                         itunes.setAuthor(author);                               // <itunes:author>
                     }

--- a/dspace-api/src/main/java/org/dspace/app/util/SyndicationFeed.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/SyndicationFeed.java
@@ -299,7 +299,7 @@ public class SyndicationFeed
                 }
 
                 // This gets the authors into an ATOM feed
-                List<SyndPerson> creators = new ArrayList<SyndPerson>();
+                List<SyndPerson> atomCreators = new ArrayList<SyndPerson>();
                 for (String authorField : authorFields) {
                     Metadatum authors[] = item.getMetadataByMetadataString(authorField);
                     if (authors.length > 0)
@@ -308,12 +308,12 @@ public class SyndicationFeed
                         {
                             SyndPerson sp = new SyndPersonImpl();
                             sp.setName(author.value);
-                            creators.add(sp);
+                            atomCreators.add(sp);
                         }
                     }
                 }
-                if (creators.size() > 0) {
-                    entry.setAuthors(creators);
+                if (atomCreators.size() > 0) {
+                    entry.setAuthors(atomCreators);
                 }
 
                 // only add DC module if any DC fields are configured
@@ -326,12 +326,12 @@ public class SyndicationFeed
                         Metadatum dcAuthors[] = item.getMetadataByMetadataString(dcCreatorField);
                         if (dcAuthors.length > 0)
                         {
-                            List<String> dcCreators = new ArrayList<String>();
+                            List<String> creators = new ArrayList<String>();
                             for (Metadatum author : dcAuthors)
                             {
-                                dcCreators.add(author.value);
+                                creators.add(author.value);
                             }
-                            dc.setCreators(dcCreators);
+                            dc.setCreators(creators);
                         }
                     }
                     if (dcDateField != null && !hasDate)

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1571,7 +1571,7 @@ webui.feed.item.date = dc.date.issued
 webui.feed.item.description = sedici.subtype, dc.title.alternative, sedici.identifier.handle, sedici.relation.*, sedici.contributor.*, \
                               thesis.degree.*, dc.description.abstract, dc.publisher, sedici.description.note, sedici.relation
 # name of field to use for authors (Atom only) - repeatable
-webui.feed.item.author = sedici.creator.*
+webui.feed.item.author = sedici.creator.*, sedici.contributor.translator, sedici.contributor.compiler
 
 # Customize the extra namespaced DC elements added to the item (RSS) or entry
 # (Atom) element.  These let you include individual metadata values in a

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1571,7 +1571,7 @@ webui.feed.item.date = dc.date.issued
 webui.feed.item.description = sedici.subtype, dc.title.alternative, sedici.identifier.handle, sedici.relation.*, sedici.contributor.*, \
                               thesis.degree.*, dc.description.abstract, dc.publisher, sedici.description.note, sedici.relation
 # name of field to use for authors (Atom only) - repeatable
-webui.feed.item.author = sedici.creator.*, sedici.contributor.translator, sedici.contributor.compiler
+webui.feed.item.author = sedici.creator.*, sedici.contributor.translator, sedici.contributor.compiler, sedici.contributor.editor
 
 # Customize the extra namespaced DC elements added to the item (RSS) or entry
 # (Atom) element.  These let you include individual metadata values in a


### PR DESCRIPTION
Ahora se permite tener valores múltiples en el setting webui.feed.item.author, por ej:
   webui.feed.item.author = sedici.creator.*, sedici.contributor.translator, sedici.contributor.compiler

Cambio la configuración de esta propiedad en dspace.cfg tal y como se muestra en el ejemplo.