### PR TITLE
-#6142 Se agrego mapeo a Crossref cuando un Libro no tiene ISBN

### DIFF
--- a/dspace/config/crosswalks/DIM2Crossref.xsl
+++ b/dspace/config/crosswalks/DIM2Crossref.xsl
@@ -277,7 +277,7 @@
 						<xsl:call-template name="setISBN" />
 					</xsl:when>
 					<xsl:when test="java:ar.edu.unlp.sedici.dspace.utils.Utils.trimAndLowercase($isbn) = $no-isbn-internal-flag">
-					   <xsl:variable name="issued_dt" select="dspace:field[@mdschema='dc' and @element='date' and @qualifier='issued'][1]"/>
+					   <xsl:variable name="issued_dt" select="substring(dspace:field[@mdschema='dc' and @element='date' and @qualifier='issued'][1]/text(),1,4)"/>
 					   <xsl:call-template name="setNoISBN">
 					       <xsl:with-param name="reason">
 					           <xsl:choose>

--- a/dspace/config/crosswalks/DIM2Crossref.xsl
+++ b/dspace/config/crosswalks/DIM2Crossref.xsl
@@ -281,11 +281,11 @@
 					   <xsl:call-template name="setNoISBN">
 					       <xsl:with-param name="reason">
 					           <xsl:choose>
-					               <!-- if book publication date is lesser than 1966 (the creation of ISBN agency)... -->
-		                           <xsl:when test="$issued_dt &lt; 1966"><xsl:value-of select="'archive_volume'" /></xsl:when>
-		                           <!-- when issued date is greater than 1966 or the book has no issued, then define this as a 'monograph'-->
-		                           <xsl:otherwise><xsl:value-of select="'monograph'"/></xsl:otherwise>
-		                       </xsl:choose>
+					               	<!-- if book publication date is lesser than 1966 (the creation of ISBN agency)... -->
+						   	<xsl:when test="$issued_dt &lt; 1966"><xsl:value-of select="'archive_volume'" /></xsl:when>
+						   	<!-- when issued date is greater than 1966 or the book has no issued, then define this as a 'monograph'-->
+						   	<xsl:otherwise><xsl:value-of select="'monograph'"/></xsl:otherwise>
+					    	   </xsl:choose>
 					       </xsl:with-param>
 					   </xsl:call-template>
 					</xsl:when>

--- a/dspace/config/crosswalks/DIM2Crossref.xsl
+++ b/dspace/config/crosswalks/DIM2Crossref.xsl
@@ -12,7 +12,7 @@
 	<xsl:output method="xml" indent="yes" encoding="utf-8" />
 
     <!-- Internal repository flag to indicate that an specified item has no ISBN -->
-    <xsl:variable name="no-isbn-internal-flag"><xsl:value-of select="'No posee'" /></xsl:variable>
+    <xsl:variable name="no-isbn-internal-flag"><xsl:value-of select="'no posee'" /></xsl:variable>
 
 	<xsl:template match="@* | text()" />
 
@@ -276,7 +276,7 @@
 						test="java:ar.edu.unlp.sedici.dspace.utils.Utils.matchRegex($isbn, '(978-)?\d[\d \-]+[\dX]')">
 						<xsl:call-template name="setISBN" />
 					</xsl:when>
-					<xsl:when test="$isbn = $no-isbn-internal-flag">
+					<xsl:when test="java:ar.edu.unlp.sedici.dspace.utils.Utils.trimAndLowercase($isbn) = $no-isbn-internal-flag">
 					   <xsl:variable name="issued_dt" select="dspace:field[@mdschema='dc' and @element='date' and @qualifier='issued'][1]"/>
 					   <xsl:call-template name="setNoISBN">
 					       <xsl:with-param name="reason">

--- a/dspace/config/crosswalks/DIM2Crossref.xsl
+++ b/dspace/config/crosswalks/DIM2Crossref.xsl
@@ -11,6 +11,9 @@
 
 	<xsl:output method="xml" indent="yes" encoding="utf-8" />
 
+    <!-- Internal repository flag to indicate that an specified item has no ISBN -->
+    <xsl:variable name="no-isbn-internal-flag"><xsl:value-of select="'No posee'" /></xsl:variable>
+
 	<xsl:template match="@* | text()" />
 
 	<xsl:template match="/dspace:dim[@dspaceType='ITEM']">
@@ -272,6 +275,19 @@
 					<xsl:when
 						test="java:ar.edu.unlp.sedici.dspace.utils.Utils.matchRegex($isbn, '(978-)?\d[\d \-]+[\dX]')">
 						<xsl:call-template name="setISBN" />
+					</xsl:when>
+					<xsl:when test="$isbn = $no-isbn-internal-flag">
+					   <xsl:variable name="issued_dt" select="dspace:field[@mdschema='dc' and @element='date' and @qualifier='issued'][1]"/>
+					   <xsl:call-template name="setNoISBN">
+					       <xsl:with-param name="reason">
+					           <xsl:choose>
+					               <!-- if book publication date is lesser than 1966 (the creation of ISBN agency)... -->
+		                           <xsl:when test="$issued_dt &lt; 1966"><xsl:value-of select="'archive_volume'" /></xsl:when>
+		                           <!-- when issued date is greater than 1966 or the book has no issued, then define this as a 'monograph'-->
+		                           <xsl:otherwise><xsl:value-of select="'monograph'"/></xsl:otherwise>
+		                       </xsl:choose>
+					       </xsl:with-param>
+					   </xsl:call-template>
 					</xsl:when>
 					<xsl:otherwise>
 						<dspaceCrswalk:error>Error: sedici.identifier.isbn not valid</dspaceCrswalk:error>
@@ -656,6 +672,14 @@
 				</isbn>
 			</xsl:if>
 		</xsl:for-each>
+	</xsl:template>
+	
+	<xsl:template name="setNoISBN">
+	   <!-- reason = archive_volume|monograph|simple_series -->
+	   <xsl:param name="reason"/>
+	   <noisbn xmlns="http://www.crossref.org/schema/4.4.2">
+	       <xsl:attribute name="reason"><xsl:value-of select="$reason"/></xsl:attribute>
+	   </noisbn>
 	</xsl:template>
 
 	<xsl:template name="setAIProgram">

--- a/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/utils/Utils.java
+++ b/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/utils/Utils.java
@@ -71,5 +71,13 @@ public class Utils {
 		String doiRegex = "((https?:\\/\\/(dx\\.)?doi.org\\/)|(doi:))10\\.[0-9]{4,9}\\/.{1,200}";
 		return java.util.regex.Pattern.matches(doiRegex, identifier);
 	}
+	
+	public static String trimAndLowercase(String value) {
+	    return value.trim().toLowerCase();
+	}
+	
+	public static String lowercase(String value) {
+	    return value.toLowerCase();
+	}
 
 }


### PR DESCRIPTION
Cuando un Libro _"No posee"_ un ISBN (internamente se registra con este valor cuando un Libro no posee ISBN porque no existe) entonces, se agrega una etiqueta `<noisbn>` para indicar que este no existe. De esta forma se puede subir a Crossref y no generarse error.

Cuando un Libro directamente no tiene el metadato _sedici.identifier.isbn_, entonces todo sigue el flujo normal y se muestra la etiqueta de error de mapeo.

http://data.crossref.org/reports/help/schema_doc/4.4.2/schema_4_4_2.html#noisbn