### PR TITLE
-#6099  Cómo citar: enlaces externos e identificadores

### DIFF
--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
@@ -2931,6 +2931,6 @@
 <message key="sedici.home.slide_pairs_contact.title">Institutional documents</message>
 <message key="sedici.home.slide_pairs_contact.info">Institutional, informative, normative and administrative documents of the University</message>
 
-<message key="sedici.items.handle.utilizacion_URI">Please, use this identificator(URI) for cite o linking this item: </message>
+<message key="sedici.items.handle.utilizacion_URI">Please, use one of this identificators(URI) for cite o linking this item: </message>
 <message key="sedici.common.camposObligatorios">(*) Mandatory fields</message>
 </catalogue>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages_es.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages_es.xml
@@ -3134,7 +3134,7 @@ Cuando se usa QDC para los elementos de DSpace se recomienda el uso de crosswalk
 <message key="sedici.home.slide_pairs_contact.title">Documentos institucionales</message>
 <message key="sedici.home.slide_pairs_contact.info">Documentos de carácter institucional, informativos, normativos y administrativos de la Universidad</message>
 
-<message key="sedici.items.handle.utilizacion_URI">Por favor, utilice este identificador(URI) para citar o enlazar este ítem: </message>
+<message key="sedici.items.handle.utilizacion_URI">Por favor, utilice uno de estos identificadores(URI) para citar o enlazar este ítem: </message>
 
 
 <!-- Creative Commons mensajes -->

--- a/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/xsl/aspect/artifactbrowser/item-view.xsl
@@ -537,7 +537,7 @@
 
 		<xsl:call-template name="render-normal-field">
 			<xsl:with-param name="name" select="'identifier-other'"/>
-			<xsl:with-param name="elements" select="dim:field[@element='identifier' and @qualifier='other'] "/>
+			<xsl:with-param name="elements" select="dim:field[@element='identifier' and @qualifier='other' and not(java:ar.edu.unlp.sedici.dspace.utils.Utils.isDoi(text()))] "/>
 			<xsl:with-param name="separator" select="' | '"/>
 			<xsl:with-param name="type" select="'url'"/>
 		</xsl:call-template>
@@ -688,10 +688,10 @@
 		</xsl:if>
 		
 		<!-- Info about how to cite this document -->
-		<xsl:if test="./dim:field[@element='identifier'][@qualifier='uri']">
+		<xsl:if test="./dim:field[@mdschema='dc'][@element='identifier'][@qualifier='uri'] or ./dim:field[@mdschema='sedici' and @element='identifier' and @qualifier='other' and java:ar.edu.unlp.sedici.dspace.utils.Utils.isDoi(text())]">
 			<div id="item-URI-suggestion">
 				<b><i18n:text>sedici.items.handle.utilizacion_URI</i18n:text></b>
-				<xsl:for-each select="dim:field[@element='identifier' and @qualifier='uri']">
+				<xsl:for-each select="dim:field[(@mdschema='dc' and @element='identifier' and @qualifier='uri') or (@mdschema='sedici' and @element='identifier' and @qualifier='other' and java:ar.edu.unlp.sedici.dspace.utils.Utils.isDoi(text()))]">
 					<li>
 						<a target="_blank"><xsl:attribute name="href"><xsl:value-of select="." /></xsl:attribute><xsl:value-of select="." /></a>
 					</li>


### PR DESCRIPTION
En la vista de un item, en la parte de identificadores para citar el item, ahora además del handle y los dois de dc.identifier.uri también se muestra, si existe, el doi de sedici.identifier.other.
A su vez quité la visualización de los identificadores externos, metadato sedici.identifier.uri, de esa sección. Ahora los identificadores externos solo se muestran en su sección de 'Enlace externo'.
El doi ahora no se muestra en la sección de 'otros identificadores'.

