### PR TITLE
-#6186 No se genera más la excepción SearchServiceException en dspace.log

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -2072,7 +2072,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
             if("equals".equals(operator) || "notequals".equals(operator))
             {
                 //DO NOT ESCAPE RANGE QUERIES !
-                if(!value.matches("\\[.*TO.*\\]"))
+                if(!value.matches("\\[.* TO .*\\]"))
                 {
                     value = ClientUtils.escapeQueryChars(value);
                     filterQuery.append(value);
@@ -2090,7 +2090,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
             }
             else{
                 //DO NOT ESCAPE RANGE QUERIES !
-                if(!value.matches("\\[.*TO.*\\]"))
+                if(!value.matches("\\[.* TO .*\\]"))
                 {
                     value = ClientUtils.escapeQueryChars(value);
                     filterQuery.append("(").append(value).append(")");


### PR DESCRIPTION
 En SolrServiceImpl, en la regex de detección de range queries,  agrego un espacio antes y después de la palabra clave "TO" para la correcta detección de las queries por rango. El problema era que si el espacio no está entonces solr no interpreta bien el rango y genera una excepción