### PR TITLE
#6204 Cambiar impresión de NPE por una excepción mas entendible cuando falta atributo en una XMLWorkflow request

### DIFF
--- a/dspace-xmlui/src/main/resources/aspects/XMLWorkflow/xmlworkflow.js
+++ b/dspace-xmlui/src/main/resources/aspects/XMLWorkflow/xmlworkflow.js
@@ -114,6 +114,10 @@ function doWorkflow()
 {
     var contextPath = cocoon.request.getContextPath();
     var workflowItemId = cocoon.request.get("workflowID");
+    if (workflowItemId == null)
+    {
+        throw "Unable to find workflow, no workflow id supplied.";
+    }
     // Get the collection handle for this item.
     var xmlWorkflowItem = XmlWorkflowItem.find(getDSContext(), workflowItemId);
     if(xmlWorkflowItem == null) {
@@ -129,10 +133,7 @@ function doWorkflow()
     var step = workflow.getStep(cocoon.request.get("stepID"));
 
 
-    if (workflowItemId == null)
-    {
-        throw "Unable to find workflow, no workflow id supplied.";
-    }else if(step == null){
+    if(step == null){
         throw "Unable to find step, no step id supplied.";
     }
     var action = step.getActionConfig(cocoon.request.get("actionID"));


### PR DESCRIPTION
Adelanté un verificación por el atributo "workflowID" para evitar generar una excepción por NPE. Sin embargo, aunque se debe generar una excepción, en vez de NPE debe indicarse el motivo correcto, es decir que no se especificó el workflow ID en la petición.

Para generar esta excepción, tomar alguna tarea del workflow: al cargar la página, luego pegar y copiar la URL pero sin los parámetros especificados. Por ejemplo, en vez de `http://localhost:9090/handle/10915/84089/xmlworkflow?workflowID=XZY&stepID=StepYY&actionID=acXX`, utilizar `http://localhost:9090/handle/10915/84089/xmlworkflow`.

Corroborar que el workflow siga funcionando bien. Para mas info sobre esta situación, leer el ticket 6204.