### PR TITLE
#6136 Agrego manejo de las excepciones QueryExceptionHTTP y ExprException en la tarea de curation MetadataAuthorityQualityControl

### DIFF
--- a/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/curation/MetadataAuthorityQualityControl.java
+++ b/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/curation/MetadataAuthorityQualityControl.java
@@ -8,6 +8,9 @@ import org.dspace.content.authority.Choices;
 import org.dspace.content.authority.MetadataAuthorityManager;
 import org.dspace.curate.AbstractCurationTask;
 import org.dspace.curate.Curator;
+
+import com.hp.hpl.jena.sparql.expr.ExprException;
+
 import java.io.IOException;
 import java.sql.SQLException;
 
@@ -102,7 +105,12 @@ public class MetadataAuthorityQualityControl extends AbstractCurationTask {
 				mtFieldName = mt.getField().replace(".", "_");
 				if (authManager.isAuthorityControlled(mtFieldName) && !skipMetadata(mtFieldName)
 						&& isMetadataToCheck(mtFieldName)) {
-					checkMetadataAuthority(reporter, mt, item);
+					try {
+						checkMetadataAuthority(reporter, mt, item);
+					} catch (ExprException e) {
+						report(reporter, mt, "ERROR", "An error ocurred processing metadata: ", e.getMessage());
+						e.printStackTrace();
+					}
 				}
 			}
 
@@ -199,7 +207,7 @@ public class MetadataAuthorityQualityControl extends AbstractCurationTask {
 		}
 	}
 
-	private void assertConfidenceNotFound(StringBuilder reporter, Metadatum mt) throws IOException {
+	private void assertConfidenceNotFound(StringBuilder reporter, Metadatum mt) {
 		if (mt.confidence > Choices.CF_NOTFOUND) {
 			report(reporter, mt, "ERROR", "Invalid confidence ", String.valueOf(mt.confidence), ", expected ",
 					String.valueOf(Choices.CF_NOTFOUND));

--- a/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/curation/MetadataAuthorityQualityControl.java
+++ b/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/curation/MetadataAuthorityQualityControl.java
@@ -9,6 +9,7 @@ import org.dspace.content.authority.MetadataAuthorityManager;
 import org.dspace.curate.AbstractCurationTask;
 import org.dspace.curate.Curator;
 
+import com.hp.hpl.jena.sparql.engine.http.QueryExceptionHTTP;
 import com.hp.hpl.jena.sparql.expr.ExprException;
 
 import java.io.IOException;
@@ -107,7 +108,7 @@ public class MetadataAuthorityQualityControl extends AbstractCurationTask {
 						&& isMetadataToCheck(mtFieldName)) {
 					try {
 						checkMetadataAuthority(reporter, mt, item);
-					} catch (ExprException e) {
+					} catch (ExprException | QueryExceptionHTTP e) {
 						report(reporter, mt, "ERROR", "An error ocurred processing metadata: ", e.getMessage());
 						e.printStackTrace();
 					}


### PR DESCRIPTION
Estas excepciones ocurren cuando los metadatos o sus authority keys contienen caracteres no válidos (por ej, # $%*&&") que hacen que la query al proveedor de autoridades falle y haga saltar una excepción ya sea porque no puede parsear bien la regex de consulta o porque devolvió un código http de error, generalmente 400.

Con los cambios introducidos estas excepciones se salvan y el metadato que las genera se ignora en el procesamiento, y se sigue la ejecución con los restantes.