### PR TITLE
-#6187 DOI no queda con estado inconsistente al fallar el registro online

### DIFF
--- a/dspace-api/src/main/java/org/dspace/identifier/DOIIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/DOIIdentifierProvider.java
@@ -340,6 +340,15 @@ public class DOIIdentifierProvider
                     + "is marked as DELETED.", DOIIdentifierException.DOI_IS_DELETED);
         }
         
+        // In case register fails, status must not stay null
+        if (doiRow.isColumnNull("status")) {
+            doiRow.setColumn("status", TO_BE_REGISTERED);
+            if (0 == DatabaseManager.update(context, doiRow))
+            {
+                throw new RuntimeException("Cannot update DOI status in the database for unkown reason.");
+            }
+        }
+
         // register DOI Online
         try {
             connector.registerDOI(context, dso, doi);


### PR DESCRIPTION
Ahora al momento de hacer un registerOnline() de un doi para un item, si el registro no se pudo completar por alguna falla entonces el doi queda con el status TO_BE_REGISTERED (1), en vez de con estado NULL