### PR TITLE
 "6278" index-discovery -f vacía el indice antes de reindexar

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
@@ -123,7 +123,7 @@ public class IndexClient {
             checkRebuildSpellCheck(line, indexer);
         } else {
             log.info("Updating and Cleaning Index");
-            indexer.cleanIndex(line.hasOption("f"));
+            indexer.cleanIndex(false);
             indexer.updateIndex(context, line.hasOption("f"));
             checkRebuildSpellCheck(line, indexer);
         }


### PR DESCRIPTION
Al pasar el valor -f al index-discovery, se reindexan todos los items pero sin borrar todo el índice.