### PR TITLE
Ticket#6185 Agrego chequeos por null y mejoro respuestas al usuario en distintos casos donde se generaba una NPE

### DIFF
--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/WorkflowRequirementsManager.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/WorkflowRequirementsManager.java
@@ -79,9 +79,11 @@ public class WorkflowRequirementsManager {
 
         //Then remove the current user from the inProgressUsers
         InProgressUser inProgressUser = InProgressUser.findByWorkflowItemAndEPerson(c, wfi.getID(), user.getID());
-        if (inProgressUser != null) {
-            inProgressUser.delete();
+        if (inProgressUser == null) {
+            // Trying to unclaim a task already unclaimed. Skipping
+            return;
         }
+        inProgressUser.delete();
 
         //Make sure the removed user has his custom rights removed
         XmlWorkflowManager.removeUserItemPolicies(c, wfi.getItem(), user);

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/WorkflowRequirementsManager.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/WorkflowRequirementsManager.java
@@ -78,8 +78,11 @@ public class WorkflowRequirementsManager {
         int totalUsers = InProgressUser.getNumberOfInProgressUsers(c, wfi.getID()) + InProgressUser.getNumberOfFinishedUsers(c, wfi.getID());
 
         //Then remove the current user from the inProgressUsers
-        InProgressUser.findByWorkflowItemAndEPerson(c, wfi.getID(), user.getID()).delete();
-        
+        InProgressUser inProgressUser = InProgressUser.findByWorkflowItemAndEPerson(c, wfi.getID(), user.getID());
+        if (inProgressUser != null) {
+            inProgressUser.delete();
+        }
+
         //Make sure the removed user has his custom rights removed
         XmlWorkflowManager.removeUserItemPolicies(c, wfi.getItem(), user);
         

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowManager.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowManager.java
@@ -344,7 +344,7 @@ public class XmlWorkflowManager {
         try {
             XmlWorkflowItem wi = XmlWorkflowItem.find(c, workflowItemId);
             Step currentStep = currentActionConfig.getStep();
-            if(currentActionConfig.getProcessingAction().isAuthorized(c, request, wi)){
+            if(wi != null && currentActionConfig.getProcessingAction().isAuthorized(c, request, wi)){
                 ActionResult outcome = currentActionConfig.getProcessingAction().execute(c, wi, currentStep, request);
                 return processOutcome(c, user, workflow, currentStep, currentActionConfig, outcome, wi, false);
             }else{

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/FlowUtils.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/FlowUtils.java
@@ -154,7 +154,8 @@ public class FlowUtils {
         }    
         else if(subInfo==null && submission==null)
         {
-            throw new SQLException("Unable to load Submission Information, since WorkspaceID (ID:" + workspaceID + ") is not a valid in-process submission.");
+            // Lanzo una Authorize exception en vez de una SQLException para que se retorne un 400 y no se genere una NPE
+            throw new AuthorizeException("Unable to load Submission Information, since WorkspaceID (ID:" + workspaceID + ") is not a valid in-process submission.");
         }
 
         return subInfo;

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/xmlworkflow/ClaimTasksAction.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/xmlworkflow/ClaimTasksAction.java
@@ -44,8 +44,10 @@ public class ClaimTasksAction extends AbstractAction {
                 XmlWorkflowItem workflowItem = XmlWorkflowItem.find(context, workflowID);
                 Workflow workflow = WorkflowFactory.getWorkflow(workflowItem.getCollection());
 
-                WorkflowActionConfig currentAction = workflow.getStep(poolTask.getStepID()).getActionConfig(poolTask.getActionID());
-                XmlWorkflowManager.doState(context, context.getCurrentUser(), request, workflowID, workflow, currentAction);
+                if (poolTask !=null) {
+                    WorkflowActionConfig currentAction = workflow.getStep(poolTask.getStepID()).getActionConfig(poolTask.getActionID());
+                    XmlWorkflowManager.doState(context, context.getCurrentUser(), request, workflowID, workflow, currentAction);
+                }
             }
             context.commit();
         }

--- a/dspace-xmlui/src/main/resources/aspects/XMLWorkflow/xmlworkflow.js
+++ b/dspace-xmlui/src/main/resources/aspects/XMLWorkflow/xmlworkflow.js
@@ -142,8 +142,9 @@ function doWorkflow()
     do{
         sendPageAndWait("handle/"+handle+"/xmlworkflow/getTask",{"workflowID":workflowItemId,"stepID":step.getId(),"actionID":action.getId()});
 
-        if (cocoon.request.get("submit_edit"))
-        {
+        if(action == null){
+            nullActionResponse();
+        }else if (cocoon.request.get("submit_edit")) {
             var contextPath = cocoon.request.getContextPath();
             cocoon.sendPage("xmlworkflow/finalize");
             cocoon.redirectTo(contextPath+"/handle/"+handle+"/workflow_edit_metadata?"+"workflowID=X"+workflowItemId+"&stepID="+step.getId()+"&actionID="+action.getId(), true);
@@ -156,14 +157,17 @@ function doWorkflow()
         }else{
             action = XmlWorkflowManager.doState(getDSContext(), getDSContext().getCurrentUser(), getHttpRequest(), workflowItemId, workflow, action);
             if(action == null){
-                var contextPath = cocoon.request.getContextPath();
-                cocoon.sendPage("xmlworkflow/finalize");
-                cocoon.redirectTo(contextPath+"/submissions",true);
-                //getDSContext().complete();
-                cocoon.exit();
+                nullActionResponse();
             }
         }
-
     }while(true);
 
+}
+
+function nullActionResponse(){
+    var contextPath = cocoon.request.getContextPath();
+    cocoon.sendPage("xmlworkflow/finalize");
+    cocoon.redirectTo(contextPath+"/submissions",true);
+    //getDSContext().complete();
+    cocoon.exit();
 }

--- a/dspace-xmlui/src/main/resources/aspects/XMLWorkflow/xmlworkflow.js
+++ b/dspace-xmlui/src/main/resources/aspects/XMLWorkflow/xmlworkflow.js
@@ -122,9 +122,7 @@ function doWorkflow()
     var xmlWorkflowItem = XmlWorkflowItem.find(getDSContext(), workflowItemId);
     if(xmlWorkflowItem == null) {
         FlashMessagesUtil.setErrorMessage(getHttpRequest().getSession(), "sedici.XMLWorkflow.workflowitem.notfound");
-        cocoon.sendPage("xmlworkflow/finalize");
-        cocoon.redirectTo(contextPath+"/submissions",true);
-        cocoon.exit();
+        redirectToSubmissions();
     }
 
     var coll = xmlWorkflowItem.getCollection();
@@ -143,7 +141,8 @@ function doWorkflow()
         sendPageAndWait("handle/"+handle+"/xmlworkflow/getTask",{"workflowID":workflowItemId,"stepID":step.getId(),"actionID":action.getId()});
 
         if(action == null){
-            nullActionResponse();
+            FlashMessagesUtil.setErrorMessage(getHttpRequest().getSession(), "sedici.XMLWorkflow.workflowitem.notfound");
+            redirectToSubmissions();
         }else if (cocoon.request.get("submit_edit")) {
             var contextPath = cocoon.request.getContextPath();
             cocoon.sendPage("xmlworkflow/finalize");
@@ -157,17 +156,16 @@ function doWorkflow()
         }else{
             action = XmlWorkflowManager.doState(getDSContext(), getDSContext().getCurrentUser(), getHttpRequest(), workflowItemId, workflow, action);
             if(action == null){
-                nullActionResponse();
+                redirectToSubmissions();
             }
         }
     }while(true);
 
 }
 
-function nullActionResponse(){
+function redirectToSubmissions(){
     var contextPath = cocoon.request.getContextPath();
     cocoon.sendPage("xmlworkflow/finalize");
     cocoon.redirectTo(contextPath+"/submissions",true);
-    //getDSContext().complete();
     cocoon.exit();
 }


### PR DESCRIPTION
Agrego chequeos por null en distintos casos donde saltaba NullPointerException:
- En la clase WorkflowRequirementsManager ocurría cuando se intentaba devolver a la cola del workflow un item que ya había sido devuelto. Lanzaba una NPE cuando quería eliminar un InProgressUser nulo.
- En el archivo xmlworkflow.js ocurría que el action era null generalmente porque el usuario presionaba el botón atrás del navegador y realizaba la misma acción que había hecho anteriormente.
 - En ClaimTasksAction, cuando se intentaba tomar un item al workflow propio que ya había sido tomado saltaba una NPE cuando la poolTask era nula

Mejoro respuestas en los casos donde se genera una NPE en el workflow
- En los casos del workflow donde el usuario cambia el estado de un workflowitem (por ejemplo lo acepta), luego se presiona atras en el navegador y se elige la misma u otra acción (por ejemplo rechazar), mando al usuario de vuelta a la página de submissions con un mensaje de error
- En los casos que presiona varias veces atrás y llega de nuevo a la parte de edición del item (luego de haber aceptado o rechazado un item), si quiere continuar con la edición se lanza una AuthorizeException y aparece un mensaje de "Sitio restringido"
