### PR TITLE
-#6283 Ahora el DOIConsumer hace un skip del DSO cuando no es un ítem.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/identifier/doi/DOIConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/doi/DOIConsumer.java
@@ -66,6 +66,7 @@ public class DOIConsumer implements Consumer
         {
             log.warn("DOIConsumer got an event whose subject was not an item, "
                     + "skipping: " + event.toString());
+            return;
         }
         Item item = (Item) dso;
         


### PR DESCRIPTION
	Antes solo logueaba ese caso y eso producía que salte una NPE.