### PR TITLE
 "6184" Filtro caracteres para parser de SPARQL. Saco catcheo de ResourceNotFoundException

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ConfigurableBrowse.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ConfigurableBrowse.java
@@ -143,8 +143,6 @@ public class ConfigurableBrowse extends AbstractDSpaceTransformer implements
         //Verify if we have received valid parameters
         try {
             getUserParams();
-        } catch (ResourceNotFoundException e) {
-            throw new BadRequestException("Invalid parameters");
         } catch (SQLException e) {
             throw new RuntimeException(e);
         } catch (UIException e) {

--- a/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/AuthorAuthority.java
+++ b/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/AuthorAuthority.java
@@ -121,7 +121,6 @@ public class AuthorAuthority extends SPARQLAuthorityProvider {
 			+ "} \n"); // end link
 		pqs.append("	}\n"); 
 		if (!"".equals(text)) {
-			text = normalizeTextForParserSPARQL10(text);
 			String[] tokens = text.split(",");
 			if (tokens.length > 1 && tokens[0].trim().length() > 0 && tokens[1].trim().length() > 0) {
 				pqs.append("FILTER(REGEX(?name, ?text2, \"i\") && REGEX(?surname, ?text1, \"i\"))\n");

--- a/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/GeneralSEDICIAuthorityProvider.java
+++ b/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/GeneralSEDICIAuthorityProvider.java
@@ -75,7 +75,6 @@ public abstract class GeneralSEDICIAuthorityProvider extends SPARQLAuthorityProv
 			pqs.append("}\n");
 		}
 		else {
-			filter = normalizeTextForParserSPARQL10(filter);
 			getTextFilterQuery(pqs,filter);
 			pqs.append("}\n");
 			pqs.append("ORDER BY ASC(?label)\n");

--- a/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/SPARQLAuthorityProvider.java
+++ b/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/SPARQLAuthorityProvider.java
@@ -147,7 +147,7 @@ public abstract class SPARQLAuthorityProvider implements ChoiceAuthority {
 			text = "";			
 		}
 		else {
-			text = text.replaceAll("(?i)[^a-z\\s0-9\\(\\)\\,\\.]", "");
+			text = text.replaceAll("(?i)[^a-z\\s0-9\\(\\)\\,\\.\\:\\/À-ž]", "");
 			if (text.indexOf("(") >= 0) {
 				text = text.replace("(", "\\\\(");
 			}

--- a/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/SPARQLAuthorityProvider.java
+++ b/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/SPARQLAuthorityProvider.java
@@ -56,7 +56,7 @@ public abstract class SPARQLAuthorityProvider implements ChoiceAuthority {
 		if (text == null)
 			text = "";
 		else 
-			text = text.replace("\"", "");
+			text = text.replaceAll("(?i)[^a-z\\s0-9\\(\\)\\,\\.]", "");
 
 		ParameterizedSparqlString query = this.getSparqlSearch(
 				field, text, locale, false);
@@ -88,7 +88,7 @@ public abstract class SPARQLAuthorityProvider implements ChoiceAuthority {
 
 	@Override
 	public String getLabel(String field, String key, String locale) {
-
+		key = normalizeTextForParserSPARQL10(key);
 		ParameterizedSparqlString query = this.getSparqlSearch(field,
 				key, locale, true);
 		Choice[] choices = this.evalSparql(query, 0,0);
@@ -147,6 +147,7 @@ public abstract class SPARQLAuthorityProvider implements ChoiceAuthority {
 	}
 
 	protected String normalizeTextForParserSPARQL10(String text) {
+		text = text.replaceAll("(?i)[^a-z\\s0-9\\(\\)\\,\\.]", "");
 		if (text.indexOf("(") >= 0) {
 			text = text.replace("(", "\\\\(");
 		}

--- a/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/SPARQLAuthorityProvider.java
+++ b/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/SPARQLAuthorityProvider.java
@@ -53,11 +53,7 @@ public abstract class SPARQLAuthorityProvider implements ChoiceAuthority {
 
 	@Override
 	public Choices getMatches(String field, String text, int collection, int start, int limit, String locale) {
-		if (text == null)
-			text = "";
-		else 
-			text = text.replaceAll("(?i)[^a-z\\s0-9\\(\\)\\,\\.]", "");
-
+		text = normalizeTextForParserSPARQL10(text);
 		ParameterizedSparqlString query = this.getSparqlSearch(
 				field, text, locale, false);
 		Choice[] choices = this.evalSparql(query, start, limit);
@@ -147,12 +143,17 @@ public abstract class SPARQLAuthorityProvider implements ChoiceAuthority {
 	}
 
 	protected String normalizeTextForParserSPARQL10(String text) {
-		text = text.replaceAll("(?i)[^a-z\\s0-9\\(\\)\\,\\.]", "");
-		if (text.indexOf("(") >= 0) {
-			text = text.replace("(", "\\\\(");
+		if (text == null) {
+			text = "";			
 		}
-		if (text.indexOf(")") >= 0) {
-			text = text.replace(")", "\\\\)");
+		else {
+			text = text.replaceAll("(?i)[^a-z\\s0-9\\(\\)\\,\\.]", "");
+			if (text.indexOf("(") >= 0) {
+				text = text.replace("(", "\\\\(");
+			}
+			if (text.indexOf(")") >= 0) {
+				text = text.replace(")", "\\\\)");
+			}			
 		}
 		return text;
 	}


### PR DESCRIPTION
En el ConfigurableBrowse se catcheaba ResourceNotFoundException, para lanzar un BadRequestException.

Filtro caracteres indeseables para que el parser de SPARQL no se rompa.