### PR TITLE
-#6396 Ahora todos los términos de búsqueda en Discovery deben matchear

### DIFF
--- a/dspace/solr/search/conf/schema.xml
+++ b/dspace/solr/search/conf/schema.xml
@@ -634,7 +634,7 @@
  <defaultSearchField>search_text</defaultSearchField>
 
  <!-- SolrQueryParser configuration: defaultOperator="AND|OR" -->
- <solrQueryParser defaultOperator="OR"/>
+ <solrQueryParser defaultOperator="AND"/>
 
   <!-- copyField commands copy one field to another at the time a document
         is added to the index.  It's used either to index the same field differently,

--- a/dspace/solr/search/conf/solrconfig.xml
+++ b/dspace/solr/search/conf/solrconfig.xml
@@ -845,7 +845,7 @@
        <int name="rows">10</int>
        <str name="df">search_text</str>
        <str name="q.alt">*:*</str>
-       <str name="q.op">OR</str>
+       <str name="q.op">AND</str>
        <str name="defType">edismax</str>
        <float name="tie">0.01</float>
 		<str name="qf">
@@ -899,7 +899,7 @@
 		   *,score
 		</str>
 		<str name="mm">
-		   1&lt;75%
+		   1&lt;100%
 		</str>
 		<int name="ps">100</int>
      </lst>


### PR DESCRIPTION
Se configuró el "requestHandler" del core [search] en Solr para que los resultados estén restringidos a aquellos que matcheen con todos los términos de búsqueda en la caja de busqueda de Discovery (y desde cualquier lugar que haga una búsqueda libre al endpoint "/select").

Por ejemplo, si el **"q"** recibe la siguiente consulta "**q**=*música de la antigüedad*" ahora todos los términos deberían aparecer al menos una vez en los documentos sobre los que se realiza la búsqueda. *Antes* estaba la restricción de que el operador era OR y además debían coincidir el 75% de los términos en una búsqueda si la cantidad de términos era mayor a 1.

Esto funcionaría similar a poner el operador *AND* entre todos los términos de búsqueda. Probar que esté funcionando de esta forma.