### PR TITLE
-#6396 Se cambió la cantidad mínima de términos de búsqueda en Discovery que deben matchear

### DIFF
--- a/dspace/solr/search/conf/schema.xml
+++ b/dspace/solr/search/conf/schema.xml
@@ -634,7 +634,7 @@
  <defaultSearchField>search_text</defaultSearchField>
 
  <!-- SolrQueryParser configuration: defaultOperator="AND|OR" -->
- <solrQueryParser defaultOperator="OR"/>
+ <solrQueryParser defaultOperator="AND"/>
 
   <!-- copyField commands copy one field to another at the time a document
         is added to the index.  It's used either to index the same field differently,

--- a/dspace/solr/search/conf/solrconfig.xml
+++ b/dspace/solr/search/conf/solrconfig.xml
@@ -845,7 +845,7 @@
        <int name="rows">10</int>
        <str name="df">search_text</str>
        <str name="q.alt">*:*</str>
-       <str name="q.op">OR</str>
+       <str name="q.op">AND</str>
        <str name="defType">edismax</str>
        <float name="tie">0.01</float>
 		<str name="qf">
@@ -899,7 +899,7 @@
 		   *,score
 		</str>
 		<str name="mm">
-		   1&lt;75%
+        3&lt;-25% 5&lt;-40% 8&lt;5
 		</str>
 		<int name="ps">100</int>
      </lst>

--- a/dspace/solr/search/conf/solrconfig.xml
+++ b/dspace/solr/search/conf/solrconfig.xml
@@ -899,7 +899,7 @@
 		   *,score
 		</str>
 		<str name="mm">
-        3&lt;-25% 5&lt;-40% 8&lt;5
+        3&lt;-25% 5&lt;-40% 8&lt;4
 		</str>
 		<int name="ps">100</int>
      </lst>


### PR DESCRIPTION
Se configuró el [requestHandler "/select"](https://github.com/sedici/DSpace/blob/38b8db97d17bf12c4b0eecc0b5d2062bd4dd4437/dspace/solr/search/conf/solrconfig.xml#L839-L963) del core [search] en Solr para que los resultados estén restringidos a aquellos que matcheen y cumplan con las siguientes restricciones:

* **(8<4)** si hay 8 términos o menos, todos deben matchear, pero si hay mas de 8 entonces solamente 4 son requeridas.

* **(5<-40%)** si hay 5 térms o menos, todos deben matchear, pero si hay mas de 5, sólo el aprox. 60% son requeridos. Con la condición anterior (8<4), esta ultima parte de la regla se lee como "si hay de de 6 a 8" términos entonces, solo el 60% son requeridos.

* **(3<-25%)** si hay 3 o menos térms, todos deben matchear, pero si hay mas de 3, solo el apróx. 75% son requeridos. Con la regla anterior, si hay de 3 a 5 términos, solo el 75% de estos térms son requeridos.

Se debe utilizar la configuración ["mm"](https://lucene.apache.org/solr/guide/7_3/the-standard-query-parser.html) en favor de la "defaultOperator" ya que se esta utilizando "edismax" como el defType, por lo que defaultOperator es ignorado.
Ver info en https://lucene.472066.n3.nabble.com/SolR-eDismax-does-not-always-use-the-defaultOperator-quot-AND-quot-td3261500.html.

El anterior PR era el #73. 