### PR TITLE
-#6390 Ahora al instanciarse una plantilla en el formulario de autoarchivo, los metadatos copiados desde la plantilla pero que no se muestran al usuario en ese formulario (ej: 'sedici.subject'), no se pierden al completar el formulario

### DIFF
--- a/dspace-api/src/main/java/org/dspace/submit/step/DescribeStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/DescribeStep.java
@@ -172,6 +172,12 @@ public class DescribeStep extends AbstractProcessingStep
             {
                 continue;
             }
+
+            // Omit fields not visible based on user's group
+            if (!inputs[i].isVisibleOnGroup(context)) {
+                continue;
+            }
+
 	        if (inputs[i].getInputType().equals("qualdrop_value"))
 	        {
 		        @SuppressWarnings("unchecked") // This cast is correct


### PR DESCRIPTION
Antes cuando se completaba el formulario de autoarchivo, estos metadatos se perdían y no aparecían luego en el formulario de admin en la etapa de revisión, ahora se preservan y se precargan correctamente.

Lo que pasaba al finalizar cada step era:
1) Se limpiaba en base de datos todos los metadatos que deberian cargarse en ese step del input forms, se muestren o no al usuario
2) Luego se los carga con los valores que ingresó el usuario (o que fueron cargados automaticamente), descartando los metadatos que no son visibles al usuario.

La solución que implementé fue que no se limpien los metadatos que no se muestran al usuario