### PR TITLE
Ticket#6351 Correción  del mapeo a snrd

### DIFF
--- a/dspace/config/crosswalks/oai/transformers/driver-commons.xsl
+++ b/dspace/config/crosswalks/oai/transformers/driver-commons.xsl
@@ -119,8 +119,8 @@
 	</xsl:template>
 	
 <!-- dc:date - ISO 8601 compliant-->
-<!-- Removing other dc.date.* - Para reducir ambigüedad, se dejan sólo las fechas de publicación y de exposición (sólo Tesis)-->
-	<xsl:template match="/doc:metadata/doc:element[@name='dc']/doc:element[@name='date']/doc:element[@name!='issued']" />
+<!-- Removing other dc.date.* - Para reducir ambigüedad, se dejan sólo las fechas de publicación, creación y de exposición (sólo Tesis)-->
+	<xsl:template match="/doc:metadata/doc:element[@name='dc']/doc:element[@name='date']/doc:element[@name!='issued' or @name!='created']" />
 	
  	<!-- Formatting sedici.date.exposure -->
 	<xsl:template match="/doc:metadata/doc:element[@name='sedici']/doc:element[@name='date']/doc:element[@name='exposure']/doc:element/doc:field/text()">
@@ -138,6 +138,22 @@
 					<doc:field name="value">
 						<xsl:call-template name="formatdate">
 							<xsl:with-param name="datestr" select="doc:element/doc:field/text()	" />
+						</xsl:call-template>
+					</doc:field>
+				</doc:element>
+			</doc:element>
+		</xsl:if>
+	</xsl:template>
+
+	<!--  Formatting dc.date.created -->
+	<!-- Sólo procesamos y mostramos el dc.date.created si es que NO EXISTE el dc.date.issued. -->
+	<xsl:template match="/doc:metadata/doc:element[@name='dc']/doc:element[@name='date']/doc:element[@name='created']">
+		<xsl:if test="not(../../../doc:element[@name='dc']/doc:element[@name='date']/doc:element[@name='issued'])">
+			<doc:element name="created">
+				<doc:element name="es">
+					<doc:field name="value">
+						<xsl:call-template name="formatdate">
+							<xsl:with-param name="datestr" select="doc:element/doc:field/text()"/>
 						</xsl:call-template>
 					</doc:field>
 				</doc:element>

--- a/dspace/config/crosswalks/oai/transformers/snrd.xsl
+++ b/dspace/config/crosswalks/oai/transformers/snrd.xsl
@@ -13,7 +13,10 @@
 
  -->
 <xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:doc="http://www.lyncode.com/xoai" xmlns:dc="http://purl.org/dc/doc:elements/1.1/" >
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xmlns:doc="http://www.lyncode.com/xoai"
+	xmlns:dc="http://purl.org/dc/doc:elements/1.1/"
+	xmlns:java="http://xml.apache.org/xalan/java">
 	<xsl:output indent="yes" method="xml" omit-xml-declaration="yes" />
 
 	<xsl:include href="driver-commons.xsl"/>
@@ -24,11 +27,6 @@
 				  	
 	  	<xsl:variable name="context" select="'snrd'"/>
 		
-		<xsl:call-template name="sedici-identifier">
-			<xsl:with-param name="handle" select="doc:element[@name='others']/doc:field[@name='handle']/text()"/>
-			<xsl:with-param name="context-name" select="$context"/>
-		</xsl:call-template>
-			
 	  		<xsl:variable name="subtype" select="doc:element[@name='sedici']/doc:element[@name='subtype']/doc:element/doc:field/text()"/>
 			<xsl:call-template name="driver-type">
 				<xsl:with-param name="subtype" select="$subtype"/>
@@ -60,6 +58,27 @@
 					<xsl:with-param name="type"><xsl:value-of select="../../@name"/></xsl:with-param>
 					<xsl:with-param name="value"><xsl:value-of select="./text()"/></xsl:with-param>
 				</xsl:call-template>
+			</xsl:for-each>
+
+			<!-- Ver "Idenficadores alternativos" en SNRD v.2015 -->
+			<!--  sedici.identifier.other -->
+			<xsl:for-each select="doc:element[@name='sedici']/doc:element[@name='identifier']/doc:element[@name='other']/doc:element/doc:field">
+				<xsl:choose>
+					<xsl:when test="java:ar.edu.unlp.sedici.dspace.utils.Utils.isDoi(./text())">
+						<xsl:variable name="doiStartIndex"
+							select="string-length(substring-before(./text(),'10.'))+1" />
+						<xsl:call-template name="printAlternativeIdentifier">
+							<xsl:with-param name="type">doi</xsl:with-param>
+							<xsl:with-param name="value"><xsl:value-of select="substring(./text(),$doiStartIndex)" /></xsl:with-param>
+						</xsl:call-template>
+					</xsl:when>
+					<xsl:when test="contains(./text(),'hdl.handle.net')">
+						<xsl:call-template name="printAlternativeIdentifier">
+							<xsl:with-param name="type">hdl</xsl:with-param>
+							<xsl:with-param name="value"><xsl:value-of select="substring-after(./text(),'http://hdl.handle.net/')"/></xsl:with-param>
+						</xsl:call-template>
+					</xsl:when>
+				</xsl:choose>
 			</xsl:for-each>
 			
 			<xsl:apply-templates select="@*|node()" />

--- a/dspace/config/crosswalks/oai/transformers/snrd.xsl
+++ b/dspace/config/crosswalks/oai/transformers/snrd.xsl
@@ -212,8 +212,9 @@
 				<xsl:when test="$language='it'">
 					ita
 				</xsl:when>
+				<!-- Si no es un lenguaje que soportemos, lo seteo como 'Sin determinar' ('Undetermined') -->
 				<xsl:otherwise>
-					<xsl:value-of select="$language"/>
+					und
 				</xsl:otherwise>
 			</xsl:choose>
 		</xsl:variable>

--- a/dspace/config/crosswalks/oai/xoai.xml
+++ b/dspace/config/crosswalks/oai/xoai.xml
@@ -594,8 +594,6 @@
 	    			<string>Capitulo de libro</string>
 		    		<string>Objeto de conferencia</string>
 			    	<string>Resumen</string>
-				    <string>Edicion de revista</string>
-    				<string>Boletin</string>
     				<string>Conjunto de datos</string>
     			</list>
 			</Configuration>


### PR DESCRIPTION
Siguiendo las directrices, y a partir del reporte informado por snrd, corregí algunas reglas y tranformaciones en el mapeo a snrd:
* Ahora si el idioma no está definido o es 'other' se mapea como 'und' (undefined según la regla ISO)
* Ahora no se mapean los items de tipo 'Publicación Seriada', ya que no tiene tipo equivalente en snrd.
* Si el ítem no tiene dc.date.issued pero tiene dc.date.created, se utiliza ese metadato para indicar la fecha de creación, esto es muy común en los conjuntos de datos.
* Los dois y handles se sedici.identifier.other ahora se mapean a dc:relation como alternate identifiers
* Ya no se duplica más dc:identifier en el mapeo