### PR TITLE
-#6566 Ahora en el mapeo a snrd se filtran los items que tengan fulltext=false

### DIFF
--- a/dspace/config/crosswalks/oai/transformers/driver-commons.xsl
+++ b/dspace/config/crosswalks/oai/transformers/driver-commons.xsl
@@ -46,7 +46,7 @@
 		</xsl:variable>
 
 		<xsl:choose>
-			<xsl:when test="not(count($bitstreams) = 0) and count($embargoed[text() = 'forever']) = count($bitstreams) ">
+			<xsl:when test="count($bitstreams) &gt; 0 and count($embargoed[text() = 'forever']) = count($bitstreams) ">
 				<doc:element name='driver'>
 					<doc:element name='rights'>
 						<doc:element name='accessRights'>

--- a/dspace/config/crosswalks/oai/transformers/driver-commons.xsl
+++ b/dspace/config/crosswalks/oai/transformers/driver-commons.xsl
@@ -46,7 +46,7 @@
 		</xsl:variable>
 
 		<xsl:choose>
-			<xsl:when test="count($bitstreams) = 0 or count($embargoed[text() = 'forever']) = count($bitstreams) ">
+			<xsl:when test="not(count($bitstreams) = 0) and count($embargoed[text() = 'forever']) = count($bitstreams) ">
 				<doc:element name='driver'>
 					<doc:element name='rights'>
 						<doc:element name='accessRights'>

--- a/dspace/config/crosswalks/oai/xoai.xml
+++ b/dspace/config/crosswalks/oai/xoai.xml
@@ -381,7 +381,14 @@
                     <RightCondition>
                         <And>
                             <LeftCondition>
-                                <Custom ref="snrdDocumentTypeCondition"/>
+                                <And>
+                                    <LeftCondition>
+                                        <Custom ref="snrdDocumentTypeCondition"/>
+                                    </LeftCondition>
+                                    <RightCondition>
+                                        <Custom ref="fulltextOnlyFilter"/>
+                                    </RightCondition>
+                                </And>
                             </LeftCondition>
                             <RightCondition>
                                 <Or>


### PR DESCRIPTION
Como los items de acceso cerrado (closed access) no se deben mapear a snrd entonces utilizamos el criterio del fulltext para identificar a los items del repo a los que no se tiene acceso a su bitstream.
Todavía faltan filtrar los que tienen sus bistreams con embargo forever.
Y ahora los items que no tienen bitstreams no necesariamente los marcamos como acceso cerrado, solo a aquellos que tienen fulltext en false, ya que los que tienen fulltext en true pueden tener un enlace externo al documento.