### PR TITLE
#6620 Ahora no se pierde la autoridad cuando se realiza una importación por csv

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
@@ -1169,7 +1169,7 @@ public class MetadataImport
      */
     private static boolean isAuthorityControlledField(String md)
     {
-        String mdf = StringUtils.substringAfter(md, ":");
+        String mdf = md.contains(":") ? StringUtils.substringAfter(md, ":") : md;
         mdf = StringUtils.substringBefore(mdf, "[");
         return authorityControlled.contains(mdf);
     }


### PR DESCRIPTION

Se hizo cherry pick con el commit AndrewZWood@ad9e0b9, el cual esta como pull request a dspace DSpace@ad9e0b9, para arreglar la issue:
 DS-3994 Authority ID & Confidence during CSV batch import not respected
pero todavia no está mergeado con 5.x