### PR TITLE
-#6699 Ahora el comando filter-media, cuando falla, loguea en std.error el nombre del bitsream y el handle del item además del stacktrace de la excepción.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterManager.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterManager.java
@@ -573,6 +573,8 @@ public class MediaFilterManager
                 	System.out.println("\tChecksum: " + checksum);
                 	System.out.println("\tAsset Store: " + assetstore);
                 	System.out.println(e);
+                    System.err.println("Error filtering bitstream \"" + myBitstream.getName() + "\"");
+                    System.err.println("Item Handle:" + handle);
                     e.printStackTrace();
                 }
     		}


### PR DESCRIPTION
Esto hace que en la cronjob de filter-media los mail enviados a los administradores contengan información mucho más util.