### PR TITLE
-#6721 Se agregó el type "Proyecto"

### DIFF
--- a/dspace/config/crosswalks/oai/transformers/driver-commons.xsl
+++ b/dspace/config/crosswalks/oai/transformers/driver-commons.xsl
@@ -230,9 +230,6 @@
 			<xsl:when test="$subtype='Convenio'">
 				info:eu-repo/semantics/annotation
 			</xsl:when>
-			<xsl:when test="$subtype='Proyecto'">
-				info:eu-repo/semantics/annotation
-			</xsl:when>
 			<xsl:when test="$subtype='Informe'">
 				info:eu-repo/semantics/annotation
 			</xsl:when>
@@ -240,6 +237,12 @@
 				info:eu-repo/semantics/other
 			</xsl:when> 
 			<xsl:when test="$subtype='Video'">
+				info:eu-repo/semantics/other
+			</xsl:when>
+			<xsl:when test="$subtype='Proyecto de extension'">
+				info:eu-repo/semantics/other
+			</xsl:when>
+			<xsl:when test="$subtype='Proyecto de investigacion'">
 				info:eu-repo/semantics/other
 			</xsl:when>
  			<xsl:when test="$subtype='Audio'">
@@ -278,9 +281,6 @@
 				info:eu-repo/semantics/publishedVersion
 			</xsl:when>
 			<xsl:when test="$subtype='Convenio'">
-				info:eu-repo/semantics/publishedVersion
-			</xsl:when>
-			<xsl:when test="$subtype='Proyecto'">
 				info:eu-repo/semantics/publishedVersion
 			</xsl:when>
 			<xsl:when test="$subtype='Informe'">
@@ -335,6 +335,12 @@
 				info:eu-repo/semantics/publishedVersion
 			</xsl:when>
  			<xsl:when test="$subtype='Audio'">
+				info:eu-repo/semantics/publishedVersion
+			</xsl:when>
+ 			<xsl:when test="$subtype='Proyecto de extension'">
+				info:eu-repo/semantics/publishedVersion
+			</xsl:when>
+ 			<xsl:when test="$subtype='Proyecto de investigacion'">
 				info:eu-repo/semantics/publishedVersion
 			</xsl:when>
 			<xsl:otherwise>

--- a/dspace/config/crosswalks/oai/transformers/snrd.xsl
+++ b/dspace/config/crosswalks/oai/transformers/snrd.xsl
@@ -156,6 +156,12 @@
 			<xsl:when test="$subtype='Conjunto de datos'">
 				conjunto de datos
 			</xsl:when>
+            <xsl:when test="$subtype='Proyecto de extension'">
+                proyecto de investigación
+            </xsl:when>
+            <xsl:when test="$subtype='Proyecto de investigacion'">
+                proyecto de investigación
+            </xsl:when>
 			<!-- No se exportan
 			<xsl:when test="$subtype='Documento institucional'">
 				otros

--- a/dspace/config/crosswalks/oai/xoai.xml
+++ b/dspace/config/crosswalks/oai/xoai.xml
@@ -522,7 +522,8 @@
 					<string>Boletin</string>
 					<string>Conjunto de datos</string>
 					<string>Convenio</string>
-					<string>Proyecto</string>
+					<string>Proyecto de extension</string>
+					<string>Proyecto de investigacion</string>
 					<string>Informe</string>
                 </list>
             </Configuration>
@@ -602,6 +603,8 @@
 		    		<string>Objeto de conferencia</string>
 			    	<string>Resumen</string>
     				<string>Conjunto de datos</string>
+    				<string>Proyecto de extension</string>
+    				<string>Proyecto de investigacion</string>
     			</list>
 			</Configuration>
 		</CustomCondition>

--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -193,6 +193,17 @@
 					<visibility-on-group>Bibliotecarios</visibility-on-group>
 					<type-bind>Conjunto de datos</type-bind>
 				</field>
+				
+				<field>
+					<dc-schema>sedici</dc-schema>
+					<dc-element>subtype</dc-element>
+					<label>Especifique el tipo de Proyecto (*)</label>
+					<input-type value-pairs-name="common_subtypes_proyecto">dropdown</input-type>
+					<hint>Seleccione el tipo de proyecto que desea cargar</hint>
+					<required-on-group>Bibliotecarios</required-on-group>
+					<visibility-on-group>Bibliotecarios</visibility-on-group>
+					<type-bind>Proyecto</type-bind>
+				</field>
 
 				<!-- /////////////////// FIN DE LOS TYPES Y SUBTYPES /////////////////// -->
 
@@ -650,7 +661,7 @@
 					<label>Evaluación</label>
 					<input-type value-pairs-name="common_evaluations">dropdown</input-type>
 					<hint>Tipo de evaluación a la que el recurso fue sometido</hint>
-					<type-bind>Articulo,Objeto de conferencia,Publicacion seriada</type-bind>
+					<type-bind>Articulo,Objeto de conferencia,Publicacion seriada,Proyecto</type-bind>
 					<visibility-on-group>Bibliotecarios</visibility-on-group>
 				</field>
 
@@ -1042,6 +1053,10 @@
 				<displayed-value>Conjunto de datos</displayed-value>
 				<stored-value>Conjunto de datos</stored-value>
 			</pair>
+			<pair>
+				<displayed-value>Proyecto</displayed-value>
+				<stored-value>Proyecto</stored-value>
+			</pair>
 		</value-pairs>
 		
 		<value-pairs value-pairs-name="common_subtypes_articulo" dc-term="type">
@@ -1208,10 +1223,6 @@
 				<stored-value>Convenio</stored-value>
 			</pair>
 			<pair>
-				<displayed-value>Proyecto</displayed-value>
-				<stored-value>Proyecto</stored-value>
-			</pair>
-			<pair>
 				<displayed-value>Informe</displayed-value>
 				<stored-value>Informe</stored-value>
 			</pair>
@@ -1291,6 +1302,17 @@
 				<stored-value>Placa fotografica</stored-value>
 			</pair>
 		</value-pairs>
+		
+        <value-pairs value-pairs-name="common_subtypes_proyecto" dc-term="type">
+            <pair>
+                <displayed-value>Proyecto de extensión</displayed-value>
+                <stored-value>Proyecto de extension</stored-value>
+            </pair>
+            <pair>
+                <displayed-value>Proyecto de investigación</displayed-value>
+                <stored-value>Proyecto de investigacion</stored-value>
+            </pair>
+        </value-pairs>
 
 
 		<!-- default language order: (from dspace 1.2.1) "en_US", "en", "es", "de", 

--- a/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/xsl/core/constant.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/xsl/core/constant.xsl
@@ -26,6 +26,7 @@
   <xsl:variable name="objeto_de_aprendizaje">Objeto de aprendizaje</xsl:variable>
   <xsl:variable name="publicacion_seriada">Publicacion seriada</xsl:variable>
   <xsl:variable name="conjunto_de_datos">Conjunto de datos</xsl:variable>
+  <xsl:variable name="proyecto">Proyecto</xsl:variable>
   
   	<xsl:variable name="global-theme-path">
 		<xsl:value-of 


### PR DESCRIPTION
Además de los subtypes "Proyecto de investigacion" y "Proyecto de extension".
Se eliminó el Subtype "Documento Institucional > Proyecto".
Se configuró el metadato "peerReview" para ser utilizado por los Proyectos.
Se hizo el mapeo correspondiente en OAI, y se acomdó a las directrices SNRD.