### PR TITLE
-#6800 Completo el mapeo a snrd de los conjuntos de datos de SEDICI

### DIFF
--- a/dspace/config/crosswalks/oai/metadataFormats/oai_dc.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/oai_dc.xsl
@@ -221,7 +221,12 @@
  			<xsl:for-each select="doc:metadata/doc:element[@name='bundles']/doc:element[@name='bundle' and doc:field[@name='name' and text()='ORIGINAL']]/doc:element[@name='bitstreams']/doc:element[@name='bitstream' and position()=1]/doc:field[@name='format']">
 				<dc:format><xsl:value-of select="." /></dc:format>
 			</xsl:for-each>
-			
+
+			<!--  dc.coverage.* -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='coverage']/doc:element/doc:element/doc:field[@name='value']">
+				<dc:coverage><xsl:value-of select="." /></dc:coverage>
+			</xsl:for-each>
+
 			<!--  dc.format.extent -->
  			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='format']/doc:element[@name='extent']/doc:element/doc:field[@name='value']">
 				<dc:format><xsl:value-of select="." /></dc:format>

--- a/dspace/config/crosswalks/oai/transformers/snrd.xsl
+++ b/dspace/config/crosswalks/oai/transformers/snrd.xsl
@@ -156,6 +156,12 @@
 			<xsl:when test="$subtype='Conjunto de datos'">
 				conjunto de datos
 			</xsl:when>
+			<xsl:when test="$subtype='Placa espectrografica'">
+				conjunto de datos
+			</xsl:when>
+			<xsl:when test="$subtype='Placa fotografica'">
+				conjunto de datos
+			</xsl:when>
             <xsl:when test="$subtype='Proyecto de extension'">
                 proyecto de investigación
             </xsl:when>

--- a/dspace/config/crosswalks/oai/xoai.xml
+++ b/dspace/config/crosswalks/oai/xoai.xml
@@ -603,6 +603,8 @@
 		    		<string>Objeto de conferencia</string>
 			    	<string>Resumen</string>
     				<string>Conjunto de datos</string>
+			        <string>Placa espectrografica</string>
+			        <string>Placa fotografica</string>
     				<string>Proyecto de extension</string>
     				<string>Proyecto de investigacion</string>
     			</list>


### PR DESCRIPTION
 Agrego al mapeo a snrd los tipos 'Placa espectografica' y 'Placa fotografica'
Estos dos tipos son subtipos de conjunto de datos que se deben mapear segun las directrices snrd y además porque se está armando un portal de datos nacional y queremos mapear todos los conjunto de datos de sedici.

También hay que tener en cuenta el nuevo metadato de materias FORD, no mergear hasta ver que esto este bien mapeado