### PR TITLE
Ticket#6799 Agrego metadatos sedici.subject.ford, dc.coverage.spatial y dc.coverage.temporal para los conjuntos de datos

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1818,6 +1818,13 @@ sedici.choices.jerarquias.filter.sedici.subject.materias = 5
 sedici.choices.jerarquias.include_childs.sedici.subject.materias = true
 sedici.choices.typeProperty.sedici.subject.materias = sedici:Materia
 
+choices.plugin.sedici.subject.ford = SubjectAuthority
+choices.presentation.sedici.subject.ford = suggest
+authority.controlled.sedici.subject.ford = true
+choices.closed.sedici.subject.ford = true
+sedici.choices.externalKeyProperty.sedici.subject.ford = owl:sameAs
+sedici.choices.typeProperty.sedici.subject.ford = sedici:FORD
+
 choices.plugin.dc.subject = SubjectAuthority
 choices.presentation.dc.subject = suggest
 authority.controlled.dc.subject = true

--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -524,6 +524,20 @@
 					<visibility-on-group>Bibliotecarios</visibility-on-group>
 				</field>
 
+				<!-- Clasificación FORD por áreas de investigación y desarrollo -->
+				<field>
+					<dc-schema>sedici</dc-schema>
+					<dc-element>subject</dc-element>
+					<dc-qualifier>ford</dc-qualifier>
+					<repeatable>true</repeatable>
+					<label>Clasificación FORD (*)</label>
+					<input-type>onebox</input-type>
+					<hint>Clasificación del documento por áreas de investigación y desarrollo (FORD por su sigla en inglés)</hint>
+					<required-on-group>Bibliotecarios</required-on-group>
+					<visibility-on-group>Bibliotecarios</visibility-on-group>
+					<type-bind>Conjunto de datos</type-bind>
+				</field>
+
 				<!-- Materia (de la lista de encabezamiento de LoC) -->
 				<!-- Se inhabilita temporalmente ya que no se habilitó el vocabulario contralado para este campo. -->
 <!-- 				<field> -->

--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -382,7 +382,7 @@
 					<repeatable>true</repeatable>
 					<label>Alcance temporal	</label>
 					<input-type>onebox</input-type>
-					<hint>Si el conjunto de datos es sobre un período de tiempo específico se debe indicar en este campo. Si es posible, se debe indicar el comienzo y el fin del intervalo de tiempo, de la siguiente manera: "start='DD/MM/AAAA'; end='DD/MM/AAAA';"</hint>
+					<hint>Si el conjunto de datos es sobre un período de tiempo específico se debe indicar en este campo. Si es posible, se debe indicar el comienzo y el fin del intervalo de tiempo, de la siguiente manera: "AñoComienzo-AñoFin" (por ejemplo, 1900-1978)</hint>
 					<type-bind>Conjunto de datos</type-bind>
 				</field>
 

--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -363,6 +363,29 @@
 					<type-bind>Conjunto de datos</type-bind>
 				</field>
 
+				<!-- Alcances temporal y geográfico del conjunto de datos -->
+				<field>
+					<dc-schema>dc</dc-schema>
+					<dc-element>coverage</dc-element>
+					<dc-qualifier>spatial</dc-qualifier>
+					<repeatable>true</repeatable>
+					<label>Alcance geografico</label>
+					<input-type>onebox</input-type>
+					<hint>Si el conjunto de datos es sobre una región geográfica específica se debe indicar en este campo. Si se trata de un país, se debe indicar el código correspondiente (por ejemplo, 'ARG', 'BRA' o 'USA'); si se trata de un área se debe indicar simplemente su nombre (por ejemplo 'Sureste del Chaco', 'Parque Nacional El Leoncito')</hint>
+					<type-bind>Conjunto de datos</type-bind>
+				</field>
+
+				<field>
+					<dc-schema>dc</dc-schema>
+					<dc-element>coverage</dc-element>
+					<dc-qualifier>temporal</dc-qualifier>
+					<repeatable>true</repeatable>
+					<label>Alcance temporal	</label>
+					<input-type>onebox</input-type>
+					<hint>Si el conjunto de datos es sobre un período de tiempo específico se debe indicar en este campo. Si es posible, se debe indicar el comienzo y el fin del intervalo de tiempo, de la siguiente manera: "start='DD/MM/AAAA'; end='DD/MM/AAAA';"</hint>
+					<type-bind>Conjunto de datos</type-bind>
+				</field>
+
 				<!-- Localización fisica -->
 				<field>
 					<dc-schema>mods</dc-schema>

--- a/dspace/config/registries/sedici-metadata.xml
+++ b/dspace/config/registries/sedici-metadata.xml
@@ -142,6 +142,12 @@
 	</dc-type>
 	<dc-type>
 		<schema>sedici</schema>
+		<element>subject</element>
+		<qualifier>ford</qualifier>
+		<scope_note>Clasificación FORD por áreas de investigación y desarrollo del documento</scope_note>
+	</dc-type>
+	<dc-type>
+		<schema>sedici</schema>
 		<element>description</element>
 		<qualifier>fulltext</qualifier>
 		<!-- sin calificar -->

--- a/dspace/config/registries/sedici-metadata.xml
+++ b/dspace/config/registries/sedici-metadata.xml
@@ -359,6 +359,18 @@
 		<qualifier>sherpa</qualifier>
 		<scope_note>Contiene la descripción de la licencia del journal según Sherpa</scope_note>
 	</dc-type>
+	<dc-type>
+		<schema>dc</schema>
+		<element>coverage</element>
+		<qualifier>spatial</qualifier>
+		<scope_note>Se utiliza en el caso que un conjunto de datos sea sobre una región geográfica específica</scope_note>
+	</dc-type>
+	<dc-type>
+		<schema>dc</schema>
+		<element>coverage</element>
+		<qualifier>temporal</qualifier>
+		<scope_note>Se utiliza en el caso que un conjunto de datos sea sobre un período de tiempo específico</scope_note>
+	</dc-type>
 
 
 </dspace-dc-types>

--- a/dspace/config/registries/sedici-metadata.xml
+++ b/dspace/config/registries/sedici-metadata.xml
@@ -359,18 +359,5 @@
 		<qualifier>sherpa</qualifier>
 		<scope_note>Contiene la descripción de la licencia del journal según Sherpa</scope_note>
 	</dc-type>
-	<dc-type>
-		<schema>dc</schema>
-		<element>coverage</element>
-		<qualifier>spatial</qualifier>
-		<scope_note>Se utiliza en el caso que un conjunto de datos sea sobre una región geográfica específica</scope_note>
-	</dc-type>
-	<dc-type>
-		<schema>dc</schema>
-		<element>coverage</element>
-		<qualifier>temporal</qualifier>
-		<scope_note>Se utiliza en el caso que un conjunto de datos sea sobre un período de tiempo específico</scope_note>
-	</dc-type>
-
 
 </dspace-dc-types>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
@@ -2665,7 +2665,10 @@
 <message key="xmlui.dri2xhtml.METS-1.0.item-format">Physical description</message>
 <message key="xmlui.dri2xhtml.METS-1.0.item-format-extent">Pages</message>
 <message key="xmlui.dri2xhtml.METS-1.0.item-format-medium">Materials/Techniques</message>
+<message key="xmlui.dri2xhtml.METS-1.0.item-coverage-spatial">Geografic reach</message>
+<message key="xmlui.dri2xhtml.METS-1.0.item-coverage-temporal">Temporal reach</message>
 <message key="xmlui.dri2xhtml.METS-1.0.item-subject-materias">Subjects</message>
+<message key="xmlui.dri2xhtml.METS-1.0.item-subject-ford">FORD classification</message>
 <message key="xmlui.dri2xhtml.METS-1.0.item-subject">Keywords</message>
 <message key="xmlui.dri2xhtml.METS-1.0.item-relation-journal">Journal</message>
 <message key="xmlui.dri2xhtml.METS-1.0.item-relation-event">Event</message>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages_es.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages_es.xml
@@ -2328,8 +2328,11 @@ Puede reemplazar la plantilla que gestiona el caso general dri2xhtml para mejora
 <message key="xmlui.dri2xhtml.METS-1.0.item-format">Descripción física</message>
 <message key="xmlui.dri2xhtml.METS-1.0.item-format-extent">Páginas</message>
 <message key="xmlui.dri2xhtml.METS-1.0.item-format-medium">Materiales/Técnicas</message>
+<message key="xmlui.dri2xhtml.METS-1.0.item-coverage-spatial">Alcance geográfico</message>
+<message key="xmlui.dri2xhtml.METS-1.0.item-coverage-temporal">Alcance temporal</message>
 <message key="xmlui.dri2xhtml.METS-1.0.item-dc-subject">Palabras claves</message>
 <message key="xmlui.dri2xhtml.METS-1.0.item-subject-materias">Materias</message>
+<message key="xmlui.dri2xhtml.METS-1.0.item-subject-ford">Clasificación FORD</message>
 <message key="xmlui.dri2xhtml.METS-1.0.item-relation-journal">Revista</message>
 <message key="xmlui.dri2xhtml.METS-1.0.item-relation-event">Evento</message>
 <message key="xmlui.dri2xhtml.METS-1.0.item-contributor-inscriber">Firmantes</message>

--- a/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/xsl/aspect/artifactbrowser/item-view.xsl
@@ -587,6 +587,18 @@
 			<xsl:with-param name="elements" select="dim:field[@element='audience']"/>
 		</xsl:call-template>
 
+		<!-- dc.coverage.spatial row -->
+		<xsl:call-template name="render-normal-field">
+			<xsl:with-param name="name" select="'coverage-spatial'"/>
+			<xsl:with-param name="elements" select="dim:field[@element='coverage' and @qualifier='spatial'] "/>
+		</xsl:call-template>
+
+		<!-- dc.coverage.temporal row -->
+		<xsl:call-template name="render-normal-field">
+			<xsl:with-param name="name" select="'coverage-temporal'"/>
+			<xsl:with-param name="elements" select="dim:field[@element='coverage' and @qualifier='temporal'] "/>
+		</xsl:call-template>
+
 		<!-- format row -->
 		<xsl:call-template name="render-normal-field">
 			<xsl:with-param name="name" select="'format'"/>
@@ -621,6 +633,12 @@
 					<xsl:with-param name="name" select="'subject-materias'"/>
 					<xsl:with-param name="elements" select="dim:field[@element='subject' and @qualifier='materias'] "/>
 					<xsl:with-param name="filter">subject</xsl:with-param>
+				</xsl:call-template>
+
+				<!-- subject.ford row -->
+				<xsl:call-template name="render-normal-field">
+					<xsl:with-param name="name" select="'subject-ford'"/>
+					<xsl:with-param name="elements" select="dim:field[@element='subject' and @qualifier='ford'] "/>
 				</xsl:call-template>
 
 			</div>


### PR DESCRIPTION
sedici.subject.ford contendrá la clasificación del un documento según la clasificación FORD por áreas de investigación y desarrollo.

dc.coverage.spatial se utiliza si el conjunto de datos es sobre una región geográfica

 dc.coverage.temporal se utiliza si el conjunto de datos es sobre un período de tiempo

- Solo se van a usar para conjuntos de datos, agregué esa restricción en el input-forms.
 - Cambio el input forms con las ayudas correspondientes, siguiendo las directrices SNRD de como deberían completarse estos campos
- Agrego los metadatos a sedici-metadata
- Agrego los metadatos a la vista sencilla de un item
- Para sedici.subject.ford agrego la configuración correspondiente en dspace.cfg para que el campo se controle por autoridad conectandose con drupal y sugiera valores de la clasificación FORD al momento de llenar el campo en el submission.



