### PR TITLE
Ticket#6813 Corrijo el mapeo del campo dc.relation según las directrices snrd.

### DIFF
--- a/dspace/config/crosswalks/oai/metadataFormats/oai_dc.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/oai_dc.xsl
@@ -98,6 +98,11 @@
 			<xsl:for-each select="doc:metadata/doc:element[@name='snrd']/doc:element[@name='alternativeIdentifier']/doc:field[@name='value']">
 				<dc:relation><xsl:value-of select="."/></dc:relation>
 			</xsl:for-each>
+
+			<!-- sedici.relation.isRelatedWith -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='sedici']/doc:element[@name='relation']/doc:element[@name='isRelatedWith']/doc:field[@name='value']">
+				<dc:relation><xsl:value-of select="."/></dc:relation>
+			</xsl:for-each>
 			
 			<!--sedici.contributor.compiler = creator -->
 			<xsl:for-each select="doc:metadata/doc:element[@name='sedici']/doc:element[@name='contributor']/doc:element[@name='compiler']/doc:element/doc:field[@name='value']">
@@ -243,18 +248,19 @@
  			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='format']/doc:element[@name='medium']/doc:element/doc:field[@name='value']">
 				<dc:format><xsl:value-of select="." /></dc:format>
 			</xsl:for-each>
-			
+
+<!--  Comento los mapeos a dc relation desde mods y desde sedici.relation porque son incorrectos de acuerdo a SNRD -->
 			<!-- mods.location=dc.relation -->
-			<xsl:for-each select="doc:metadata/doc:element[@name='mods']/doc:element[@name='location']/doc:element/doc:field[@name='value']">
-				<dc:relation>
-					<xsl:value-of select="." />
-				</dc:relation>
-			</xsl:for-each>
+<!-- 			<xsl:for-each select="doc:metadata/doc:element[@name='mods']/doc:element[@name='location']/doc:element/doc:field[@name='value']"> -->
+<!-- 				<dc:relation> -->
+<!-- 					<xsl:value-of select="." /> -->
+<!-- 				</dc:relation> -->
+<!-- 			</xsl:for-each> -->
 			
 			<!--sedici.relation.(event|journalTitle|journalVolumeAndIssue|dossier) = relation -->
-			<xsl:for-each select="doc:metadata/doc:element[@name='sedici']/doc:element[@name='relation']/doc:element/doc:element/doc:field[@name='value']">
-				<dc:relation><xsl:value-of select="." /></dc:relation>
-			</xsl:for-each>
+<!-- 			<xsl:for-each select="doc:metadata/doc:element[@name='sedici']/doc:element[@name='relation']/doc:element/doc:element/doc:field[@name='value']"> -->
+<!-- 				<dc:relation><xsl:value-of select="." /></dc:relation> -->
+<!-- 			</xsl:for-each> -->
 			
 			<!--mods.recordInfo.recordContentSource = source -->
 			<xsl:for-each select="doc:metadata/doc:element[@name='mods']/doc:element[@name='recordInfo']/doc:element[@name='recordContentSource']/doc:element/doc:field[@name='value']">

--- a/dspace/config/crosswalks/oai/transformers/snrd.xsl
+++ b/dspace/config/crosswalks/oai/transformers/snrd.xsl
@@ -52,10 +52,18 @@
 			</xsl:if>
 
 			<!-- Ver "Idenficadores alternativos" en SNRD v.2015 -->
-			<!--  sedici.identifier.doi, sedici.identifier.handle, sedici.identifier.isbn -->
-			<xsl:for-each select="doc:element[@name='sedici']/doc:element[@name='identifier']/doc:element[@name='doi' or @name='handle' or @name='isbn']/doc:element/doc:field">
+			<!--  sedici.identifier.doi, sedici.identifier.isbn -->
+			<xsl:for-each select="doc:element[@name='sedici']/doc:element[@name='identifier']/doc:element[@name='doi' or @name='isbn']/doc:element/doc:field">
 				<xsl:call-template name="printAlternativeIdentifier">
 					<xsl:with-param name="type"><xsl:value-of select="../../@name"/></xsl:with-param>
+					<xsl:with-param name="value"><xsl:value-of select="./text()"/></xsl:with-param>
+				</xsl:call-template>
+			</xsl:for-each>
+
+			<!-- sedici.identifier.handle -->
+			<xsl:for-each select="doc:element[@name='sedici']/doc:element[@name='identifier']/doc:element[@name='handle']/doc:element/doc:field">
+				<xsl:call-template name="printAlternativeIdentifier">
+					<xsl:with-param name="type">hdl</xsl:with-param>
 					<xsl:with-param name="value"><xsl:value-of select="./text()"/></xsl:with-param>
 				</xsl:call-template>
 			</xsl:for-each>
@@ -78,6 +86,38 @@
 							<xsl:with-param name="value"><xsl:value-of select="substring-after(./text(),'http://hdl.handle.net/')"/></xsl:with-param>
 						</xsl:call-template>
 					</xsl:when>
+					<xsl:when test="contains(./text(),'hdl:')">
+						<xsl:call-template name="printAlternativeIdentifier">
+							<xsl:with-param name="type">hdl</xsl:with-param>
+							<xsl:with-param name="value"><xsl:value-of select="substring-after(./text(),'hdl:')"/></xsl:with-param>
+						</xsl:call-template>
+					</xsl:when>
+				</xsl:choose>
+			</xsl:for-each>
+
+			<!-- sedici.relation.isRelatedWith -->
+			<xsl:for-each select="doc:element[@name='sedici']/doc:element[@name='relation']/doc:element[@name='isRelatedWith']/doc:element/doc:field">
+				<xsl:choose>
+					<xsl:when test="java:ar.edu.unlp.sedici.dspace.utils.Utils.isDoi(./text())">
+						<xsl:variable name="doiStartIndex"
+							select="string-length(substring-before(./text(),'10.'))+1" />
+						<xsl:call-template name="printRelatedPublication">
+							<xsl:with-param name="type">doi</xsl:with-param>
+							<xsl:with-param name="value"><xsl:value-of select="substring(./text(),$doiStartIndex)" /></xsl:with-param>
+						</xsl:call-template>
+					</xsl:when>
+					<xsl:when test="contains(./text(),'http://sedici.unlp.edu.ar/handle/')">
+						<xsl:call-template name="printRelatedPublication">
+							<xsl:with-param name="type">hdl</xsl:with-param>
+							<xsl:with-param name="value"><xsl:value-of select="substring-after(./text(),'http://sedici.unlp.edu.ar/handle/')"/></xsl:with-param>
+						</xsl:call-template>
+					</xsl:when>
+					<xsl:otherwise>
+						<xsl:call-template name="printRelatedPublication">
+							<xsl:with-param name="type">url</xsl:with-param>
+							<xsl:with-param name="value"><xsl:value-of select="normalize-space(./text())"/></xsl:with-param>
+						</xsl:call-template>
+					</xsl:otherwise>
 				</xsl:choose>
 			</xsl:for-each>
 			
@@ -272,5 +312,19 @@
 			</doc:element>
 		
 	</xsl:template>
-	
+
+	<xsl:template name="printRelatedPublication">
+		<xsl:param name="type"/>
+		<xsl:param name="value"/>
+		<doc:element name="sedici">
+			<doc:element name="relation">
+				<doc:element name="isRelatedWith">
+					<doc:field name="value">
+						<xsl:value-of select="concat('info:eu-repo/semantics/reference/',$type,'/', $value)"/>
+					</doc:field>
+				</doc:element>
+			</doc:element>
+		</doc:element>
+	</xsl:template>
+
 </xsl:stylesheet>

--- a/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/utils/Utils.java
+++ b/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/utils/Utils.java
@@ -68,7 +68,7 @@ public class Utils {
 	 * http(s)://doi.org/10.XXXX/XXXX,http(s)://dx.doi.org/10.XXXX/XXXX o doi:10.XXXX/XXXX
 	 */
 	public static boolean isDoi(String identifier) {
-		String doiRegex = "((https?:\\/\\/(dx\\.)?doi.org\\/)|(doi:))10\\.[0-9]{4,9}\\/.{1,200}";
+		String doiRegex = "((https?:\\/\\/(dx\\.)?doi.org\\/)|(doi:)|(DOI:))10\\.[0-9]{4,9}\\/.{1,200}";
 		return java.util.regex.Pattern.matches(doiRegex, identifier);
 	}
 	


### PR DESCRIPTION
Agrego un nuevo mapeo desde el campo sedici.relation.isRelatedWith al campo dc.relation, siguiendo el formato info:eu-repo/semantics/reference/<esquema>/<identificador>
Elimino el mapeo de varios sedici.relation.* a dc.relation que eran incorrectos
Corrijo el mapeo del metadato sedici.identifier.other


Para aprobar esto el mapeo de dc.relation debería estar de acuerdo con las directrices SNRD https://repositoriosdigitales.mincyt.gob.ar/files/Directrices_SNRD_2015.pdf
