### PR TITLE
-#6848 En el submission, al hacer hover sobre la lista de opciones de un campo controlado por autoridad las opciones no se muestras en dos lineas, sino en una

### DIFF
--- a/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/css/style.css
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/css/style.css
@@ -4078,7 +4078,7 @@ table.dropdown-table.ui-accordion tr:hover td{
 /* jQuery UI autocomplete max-height */
 .ui-autocomplete {
 	max-height: 300px;
-	overflow-y: auto;
+	overflow-y: scroll;
 	overflow-x: hidden;
 }
 


### PR DESCRIPTION
Cambio en el css responsable de las sugerencias de autoridad la propiedad "overflow-y: auto" por "overflow-y: scroll"