### PR TITLE
-#6868 Ahora se exponen todos los identificador alternativo con handle en el snrd

### DIFF
--- a/dspace/config/crosswalks/oai/transformers/snrd.xsl
+++ b/dspace/config/crosswalks/oai/transformers/snrd.xsl
@@ -75,7 +75,19 @@
 					<xsl:when test="contains(./text(),'hdl.handle.net')">
 						<xsl:call-template name="printAlternativeIdentifier">
 							<xsl:with-param name="type">hdl</xsl:with-param>
-							<xsl:with-param name="value"><xsl:value-of select="substring-after(./text(),'http://hdl.handle.net/')"/></xsl:with-param>
+							<xsl:with-param name="value"><xsl:value-of select="substring-after(./text(),'hdl.handle.net/')"/></xsl:with-param>
+						</xsl:call-template>
+					</xsl:when>
+					<xsl:when test="contains(./text(),'hdl:')">
+						<xsl:call-template name="printAlternativeIdentifier">
+							<xsl:with-param name="type">hdl</xsl:with-param>
+							<xsl:with-param name="value"><xsl:value-of select="substring-after(./text(),'hdl:')"/></xsl:with-param>
+						</xsl:call-template>
+					</xsl:when>
+					<xsl:when test="contains(./text(),'handle/')">
+						<xsl:call-template name="printAlternativeIdentifier">
+							<xsl:with-param name="type">hdl</xsl:with-param>
+							<xsl:with-param name="value"><xsl:value-of select="substring-after(./text(),'handle/')"/></xsl:with-param>
 						</xsl:call-template>
 					</xsl:when>
 				</xsl:choose>


### PR DESCRIPTION
En el mapeo del metadato sedici.identifier.other a dc.relation como altIdentifier en snrd OAI, se agregaron mas casos para poder detectar todos los handles del metadato
Ahora se detectan los casos que los handles:
* empiezan con "hdl:"
* Sean una url a un repositorio externo y el handle esta en esa url como "{URL}/handle/{handle item}" ej https://digital.cic.gba.gob.ar/handle/11746/1146
* y tambien los casos en los que el handle empieza con hdl.handle.net sin el http delante

Los metadatos de sedici.identifier.other que tengan handles se deberían mapear como
` <dc:relation>info:eu-repo/semantics/altIdentifier/hdl/1234/9987</dc:relation>`
