### PR TITLE
-#6899 En la vista de una colección o comunidad, en la visualización de los metadatos custom ahora se introduce un ";" entre los distintos valores de un mismo metadato

### DIFF
--- a/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/xsl/core/utils.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/xsl/core/utils.xsl
@@ -507,6 +507,7 @@
 			<div>
 				<xsl:attribute name="class"><xsl:value-of select="./@class"/></xsl:attribute>	
 				<!-- Seguimos parseando el string y lo convertimos en otro conjunto de nodos -->
+				<xsl:variable name="elementsCount" select="count(exslt:node-set(.)/*)" />
 				<xsl:for-each select="exslt:node-set(.)/*">
 					<xsl:choose>
 	           			<xsl:when test="./@class='value'">
@@ -525,6 +526,10 @@
            							</xsl:choose>
            						</xsl:for-each>
 	           				</span>
+				            <!-- Agrego ; si no es el ultimo elemento -->
+				            <xsl:if test="$elementsCount != position()">
+				               <xsl:text>; </xsl:text>
+				            </xsl:if>
 	           			</xsl:when>
 	           			<xsl:otherwise>
 	           				<xsl:copy-of select="."/>


### PR DESCRIPTION
Por ejemplo, entre dos entidades de origen de una colección/comunidad o entre dos lugares.
Antes si habia mas de una entidad de origen se separaban solo por un espacio, ahora se agrega un punto y coma entre ellos.