### PR TITLE
-#6929 Fix al botón 'Compartir' de facebook 

### DIFF
--- a/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/xsl/core/page-structure.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/xsl/core/page-structure.xsl
@@ -816,7 +816,7 @@ placeholders for header images -->
 			      var js, fjs = d.getElementsByTagName(s)[0];
 			      if (d.getElementById(id)) return;
 			      js = d.createElement(s); js.id = id;
-			      js.src = "//connect.facebook.net/en_US/sdk.js#xfbml=1&amp;version=v2.3&amp;appId=79106916048";
+			      js.src = "//connect.facebook.net/en_US/sdk.js#xfbml=1&amp;version=v3.0";
 			      fjs.parentNode.insertBefore(js, fjs);
 			    }(document, 'script', 'facebook-jssdk'));
 			


### PR DESCRIPTION
Ahora segun la documentación, https://developers.facebook.com/docs/plugins/share-button/#bot-n--compartir-, no se necesita mas el appId, ya que no se necesitan estar logueado ni permisos adicionales al revisar la aplicación.
También ahora se utiliza la versión 3.0 y no la 2.3 como estaba antes.

Con el dspace levantado local no funciona porque dice que no es un href válido, posiblemente porque es http://localhost/*, pero si le harcodeo una url verdadera si funciona, cosa que antes no pasaba.