### PR TITLE
Ticket#6893 Agrego seguimiento de handles de item, colecciones y comunidades ante cada pageView de un item en GoogleAnalytics

### DIFF
--- a/dspace/modules/xmlui/src/main/java/ar/edu/unlp/sedici/xmlui/xsl/XslExtensions.java
+++ b/dspace/modules/xmlui/src/main/java/ar/edu/unlp/sedici/xmlui/xsl/XslExtensions.java
@@ -183,7 +183,7 @@ public class XslExtensions {
 	 * Método que retorna los handles de las colecciones y comunidades de un item
 	 * separados por coma
 	 */
-	public static String getItemContainersList(String handle) throws SQLException {
+	public static String getItemCollsAndComms(String handle) throws SQLException {
 		Context context;
 		try {
 			context = new Context();

--- a/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/xsl/core/page-structure.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/xsl/core/page-structure.xsl
@@ -627,8 +627,8 @@ placeholders for header images -->
 				</xsl:text>
 				<xsl:if test="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='focus'][@qualifier='containerType']/text() = 'type:item'">
 					<xsl:variable name="itemHandle" select="substring(/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='focus'][@qualifier='object']/text(), 5)"/><xsl:text>
-					ga('set', 'dimension1', '</xsl:text><xsl:value-of select="$itemHandle"/><xsl:text>')
-					ga('set', 'dimension2', '</xsl:text><xsl:value-of select="ex:getItemContainersList($itemHandle)"/><xsl:text>')
+					ga('set', 'dimension1', '</xsl:text><xsl:value-of select="$itemHandle"/><xsl:text>');
+					ga('set', 'dimension2', '</xsl:text><xsl:value-of select="ex:getItemCollsAndComms($itemHandle)"/><xsl:text>');
 				</xsl:text>
 				</xsl:if><xsl:text>
 				ga('send', 'pageview');

--- a/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/xsl/core/page-structure.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/xsl/core/page-structure.xsl
@@ -627,8 +627,10 @@ placeholders for header images -->
 				</xsl:text>
 				<xsl:if test="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='focus'][@qualifier='containerType']/text() = 'type:item'">
 					<xsl:variable name="itemHandle" select="substring(/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='focus'][@qualifier='object']/text(), 5)"/><xsl:text>
+					var itemType = document.getElementsByName("DC.type")[0].content;
 					ga('set', 'dimension1', '</xsl:text><xsl:value-of select="$itemHandle"/><xsl:text>');
 					ga('set', 'dimension2', '</xsl:text><xsl:value-of select="ex:getItemCollsAndComms($itemHandle)"/><xsl:text>');
+					ga('set', 'dimension3', itemType);
 				</xsl:text>
 				</xsl:if><xsl:text>
 				ga('send', 'pageview');

--- a/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/xsl/core/page-structure.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/xsl/core/page-structure.xsl
@@ -14,7 +14,8 @@
                 xmlns="http://www.w3.org/1999/xhtml"
                 exclude-result-prefixes="i18n dri mets xlink xsl dim xhtml mods dc confman"
                 xmlns:date="http://exslt.org/dates-and-times" 
-                extension-element-prefixes="date">
+                extension-element-prefixes="date"
+                xmlns:ex="ar.edu.unlp.sedici.xmlui.xsl.XslExtensions">
 
     <xsl:output indent="yes"/>
 
@@ -624,9 +625,10 @@ placeholders for header images -->
 
 				ga('create', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='google'][@qualifier='analytics']"/><xsl:text>', 'auto');
 				</xsl:text>
-				<xsl:if test="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='focus'][@qualifier='containerType']/text() = 'type:item'"><xsl:text>
-					ga('set', 'dimension1', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='focus'][@qualifier='object']/text()"/><xsl:text>')
-					ga('set', 'dimension2', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='focus'][@qualifier='container']/text()"/><xsl:text>')
+				<xsl:if test="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='focus'][@qualifier='containerType']/text() = 'type:item'">
+					<xsl:variable name="itemHandle" select="substring(/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='focus'][@qualifier='object']/text(), 5)"/><xsl:text>
+					ga('set', 'dimension1', '</xsl:text><xsl:value-of select="$itemHandle"/><xsl:text>')
+					ga('set', 'dimension2', '</xsl:text><xsl:value-of select="ex:getItemContainersList($itemHandle)"/><xsl:text>')
 				</xsl:text>
 				</xsl:if><xsl:text>
 				ga('send', 'pageview');

--- a/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/xsl/core/page-structure.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/xsl/core/page-structure.xsl
@@ -644,7 +644,7 @@ placeholders for header images -->
 					<xsl:if test="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='focus'][@qualifier='containerType']/text() = 'type:item'"><xsl:text>
 						var itemType = document.getElementsByName("DC.type")[0].content;
 						var itemSubtype = document.getElementsByName("DC.type")[1].content;
-						var dateIssued = (document.getElementsByName("DCTERMS.issued")[0])? document.getElementsByName("DCTERMS.issued")[0].content : document.getElementsByName("DCTERMS.created")[0].content.substring(0,10);
+						var itemDateIssued = (document.getElementsByName("DCTERMS.issued")[0])? document.getElementsByName("DCTERMS.issued")[0].content : document.getElementsByName("DCTERMS.created")[0].content.substring(0,10);
 						ga('set', 'dimension3', itemType);
 						ga('set', 'dimension5', itemSubtype);
 						ga('set', 'dimension6', itemDateIssued);

--- a/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/xsl/core/page-structure.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/xsl/core/page-structure.xsl
@@ -614,17 +614,24 @@ placeholders for header images -->
 
         <!-- Add a google analytics script if the key is present -->
         <xsl:if test="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='google'][@qualifier='analytics']">
-            <script type="text/javascript"><xsl:text>
-                   var _gaq = _gaq || [];
-                   _gaq.push(['_setAccount', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='google'][@qualifier='analytics']"/><xsl:text>']);
-                   _gaq.push(['_trackPageview']);
+			<!-- Google Analytics -->
+			<script type="text/javascript"><xsl:text>
+				(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+				(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new
+				Date();a=s.createElement(o),
+				m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+				})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-                   (function() {
-                       var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-                       ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-                       var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-                   })();
-           </xsl:text></script>
+				ga('create', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='google'][@qualifier='analytics']"/><xsl:text>', 'auto');
+				</xsl:text>
+				<xsl:if test="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='focus'][@qualifier='containerType']/text() = 'type:item'"><xsl:text>
+					ga('set', 'dimension1', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='focus'][@qualifier='object']/text()"/><xsl:text>')
+					ga('set', 'dimension2', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='focus'][@qualifier='container']/text()"/><xsl:text>')
+				</xsl:text>
+				</xsl:if><xsl:text>
+				ga('send', 'pageview');
+			</xsl:text></script>
+			<!-- End Google Analytics -->
         </xsl:if>
 
 		<!-- Matomo -->

--- a/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/xsl/core/page-structure.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/xsl/core/page-structure.xsl
@@ -625,13 +625,31 @@ placeholders for header images -->
 
 				ga('create', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='google'][@qualifier='analytics']"/><xsl:text>', 'auto');
 				</xsl:text>
-				<xsl:if test="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='focus'][@qualifier='containerType']/text() = 'type:item'">
-					<xsl:variable name="itemHandle" select="substring(/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='focus'][@qualifier='object']/text(), 5)"/><xsl:text>
-					var itemType = document.getElementsByName("DC.type")[0].content;
-					ga('set', 'dimension1', '</xsl:text><xsl:value-of select="$itemHandle"/><xsl:text>');
-					ga('set', 'dimension2', '</xsl:text><xsl:value-of select="ex:getItemCollsAndComms($itemHandle)"/><xsl:text>');
-					ga('set', 'dimension3', itemType);
-				</xsl:text>
+				<xsl:if test="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='focus'][@qualifier='containerType']">
+					<xsl:variable name="dsoHandle">
+						<xsl:choose>
+						<xsl:when test="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='focus'][@qualifier='object']">
+							<xsl:value-of select="substring-after(/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='focus'][@qualifier='object']/text(), 'hdl:')"/>
+						</xsl:when>
+						<xsl:otherwise>
+							<xsl:value-of select="substring-after(/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='focus'][@qualifier='container']/text(), 'hdl:')"/>
+						</xsl:otherwise>
+						</xsl:choose>
+					</xsl:variable>
+					<xsl:text>
+					ga('set', 'dimension1', '</xsl:text><xsl:value-of select="$dsoHandle"/><xsl:text>');
+					ga('set', 'dimension2', '</xsl:text><xsl:value-of select="ex:getDSOParentsHandles($dsoHandle)"/><xsl:text>');
+					ga('set', 'dimension4', '</xsl:text><xsl:value-of select="substring-after(/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='focus'][@qualifier='containerType']/text(), 'type:')"/><xsl:text>');
+					</xsl:text>
+					<xsl:if test="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='focus'][@qualifier='containerType']/text() = 'type:item'"><xsl:text>
+						var itemType = document.getElementsByName("DC.type")[0].content;
+						var itemSubtype = document.getElementsByName("DC.type")[1].content;
+						var dateIssued = (document.getElementsByName("DCTERMS.issued")[0])? document.getElementsByName("DCTERMS.issued")[0].content : document.getElementsByName("DCTERMS.created")[0].content.substring(0,10);
+						ga('set', 'dimension3', itemType);
+						ga('set', 'dimension5', itemSubtype);
+						ga('set', 'dimension6', itemDateIssued);
+					</xsl:text>
+					</xsl:if>
 				</xsl:if><xsl:text>
 				ga('send', 'pageview');
 			</xsl:text></script>


### PR DESCRIPTION
Agrego codigo para que se registren a que item, colecciones y comunidades se les está haciendo un hit en el caso de una visita a la página de un ítem. Para ello creo 2 dimensiones personalizadas, una para items y otra para colecciones y comunidades

Los handles de las comunidades y colecciones del item se envian separados por coma en la misma dimensión. Para obtenerlos desde el xsl se creó el método getItemCollsAndComms en la clase XslExtensions.

