### PR TITLE
 "#5993" Ignoro info de autohority para dc.subject

### DIFF
--- a/dspace/config/modules/discovery.cfg
+++ b/dspace/config/modules/discovery.cfg
@@ -22,3 +22,5 @@ index.projection=dc.title,dc.contributor.*,dc.date.issued
 # 1) you need to set the DiscoverySearchRequestProcessor in the dspace.cfg 
 # 2) to show facet on Site/Community/etc. you need to add a Site/Community/Collection
 #	 Processors plugin in the dspace.cfg
+
+index.authority.ignore.dc.subject=true


### PR DESCRIPTION
No se incluye información de las autoridades para armar los facets  de palabras claves. Por ende los facets para dc.subject se arman solamente a partir del text_value y no del authority key.

Por ejemplo, si la palabra clave "Galaxia" está en la BD con la autoridad "A" y también con "B", se indexan en una misma entrada las dos. Quedando en el facet: "Galaxia (2)" y no como era hasta recién que aparecen dos entradas distintas (para filtrar por cada una de las autoridades).

