### PR TITLE
-#7025 Quito el metadato sedici.relation.dossier del input-forms y del item-view

### DIFF
--- a/dspace/config/crosswalks/xhtml-head-item.properties
+++ b/dspace/config/crosswalks/xhtml-head-item.properties
@@ -69,7 +69,6 @@ dc.relation=DC.relation
 dc.relation.ispartof=DCTERMS.isPartOf
 sedici.relation.journalTitle=DCTERMS.isPartOf
 sedici.relation.journalVolumeAndIssue=DCTERMS.isPartOf
-sedici.relation.dossier=DCTERMS.isPartOf
 dc.source=DC.source
 sedici.contributor.inscriber=DC.contributor
 sedici.identifier.expediente=DC.identifier

--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -678,18 +678,6 @@
 					<type-bind>Libro</type-bind>
 				</field>
 
-				<!-- Dossier -->
-				<field>
-					<dc-schema>sedici</dc-schema>
-					<dc-element>relation</dc-element>
-					<dc-qualifier>dossier</dc-qualifier>
-					<label>Nombre del Dossier</label>
-					<input-type>textarea</input-type>
-					<hint>Nombre de la sección Dossier en la que el artículo se encuentra</hint>
-					<type-bind>Articulo</type-bind>
-					<visibility-on-group>Bibliotecarios</visibility-on-group>
-				</field>
-
 				<!-- Evaluación -->
 				<field>
 					<dc-schema>sedici</dc-schema>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
@@ -2653,7 +2653,6 @@
 <message key="xmlui.dri2xhtml.METS-1.0.item-degree-name">Degree</message>
 <message key="xmlui.dri2xhtml.METS-1.0.item-degree-grantor">Grantor</message>
 <message key="xmlui.dri2xhtml.METS-1.0.item-date-exposure">Exposure date</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-relation-dossier">Dossier</message>
 <message key="xmlui.dri2xhtml.METS-1.0.item-originInfo">Origin</message>
 <message key="xmlui.dri2xhtml.METS-1.0.item-identifier-uri">External link</message>
 <message key="xmlui.dri2xhtml.METS-1.0.item-identifier-doi">DOI</message>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages_es.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages_es.xml
@@ -2316,7 +2316,6 @@ Puede reemplazar la plantilla que gestiona el caso general dri2xhtml para mejora
 <message key="xmlui.dri2xhtml.METS-1.0.item-degree-name">Grado alcanzado</message>
 <message key="xmlui.dri2xhtml.METS-1.0.item-degree-grantor">Institución otorgante</message>
 <message key="xmlui.dri2xhtml.METS-1.0.item-date-exposure">Fecha de exposición</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-relation-dossier">Dossier</message>
 <message key="xmlui.dri2xhtml.METS-1.0.item-originInfo">Institución de origen</message>
 <message key="xmlui.dri2xhtml.METS-1.0.item-identifier-uri">Enlace externo</message>
 <message key="xmlui.dri2xhtml.METS-1.0.item-identifier-doi">DOI</message>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages_pt_BR.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages_pt_BR.xml
@@ -2193,7 +2193,6 @@
 	<message key="xmlui.dri2xhtml.METS-1.0.item-originInfo">Origem</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-record-source">Os dados deste registro foram obtidos de</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-relation-book-title">Pertence a um livro</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.item-relation-dossier">Dossiê</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-relation-event">Evento</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-relation-isPartOfSeries">Série</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-relation-journal">Revista</message>

--- a/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/xsl/aspect/artifactbrowser/item-view.xsl
@@ -541,12 +541,6 @@
 			<xsl:with-param name="elements" select="dim:field[@element='relation' and @qualifier='event'] "/>
 		</xsl:call-template>
 
-		<!-- relation.dossier row -->
-		<xsl:call-template name="render-normal-field">
-			<xsl:with-param name="name" select="'relation-dossier'"/>
-			<xsl:with-param name="elements" select="dim:field[@element='relation' and @qualifier='dossier'] "/>
-		</xsl:call-template>
-
 		<!-- originInfo row -->
 		<xsl:call-template name="render-normal-field">
 			<xsl:with-param name="name" select="'originInfo'"/>

--- a/dspace/solr/search/conf/solrconfig.xml
+++ b/dspace/solr/search/conf/solrconfig.xml
@@ -866,7 +866,6 @@
 		  	sedici.contributor.juror^0.1
 		  	dc.relation.isPartOf^0.1
 		  	sedici.relation.event^0.1
-		  	sedici.relation.dossier^0.1
 		  	sedici.identifier.handle^0.01
 		  	sedici.identifier.issn^0.01
 		  	sedici.identifier.isbn^0.01
@@ -892,7 +891,6 @@
 		  	sedici.contributor.juror^0.1
 		  	dc.relation.isPartOf^0.1
 		  	sedici.relation.event^0.1
-		  	sedici.relation.dossier^0.1
 		  	search_text^0.001
 		</str>
 		<str name="fl">


### PR DESCRIPTION
El dato del dossier ahora se ingresa en sedici.relation.note, por lo que no es mas necesario el metadato dossier.

Hice el PR mas que nada por si hay que sacarlo de algun otro lado que se me pasó, es un cambio sencillo