### PR TITLE
#7026 Comunidades padres de una comunidad ahora se devuelven de forma ascendente por "id" de tupla (community2community)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/Community.java
+++ b/dspace-api/src/main/java/org/dspace/content/Community.java
@@ -804,7 +804,8 @@ public class Community extends DSpaceObject
                 ourContext,"community",
                 "SELECT community.* FROM community, community2community WHERE " +
                 "community2community.parent_comm_id=community.community_id " +
-                "AND community2community.child_comm_id= ? ",
+                "AND community2community.child_comm_id= ? " +
+                "ORDER BY community2community.id ASC",
                 getID());
         
         // Make Community object


### PR DESCRIPTION
Considerando la herencia múltiple de comunidad (hacia arriba) creada forzosamente al manipular la tabla _community2community_, resulta necesario devolver como primer padre el que tiene ID de tupla mas bajo en las relaciones presentes en la tabla _community2community_.

En particular para este PR hay que probar que en el trail de la página de un item aparezca como padre el primero que aparece en la tabla _community2community_.

Antes de probar estos cambios hay que ejecutar los SQL que estan en el ticket, asi se cambia el orden de las relaciones en la tabla 'community2community'.