### PR TITLE
Ticket#7113 Validación de DOI externo al momento de registrar DOI

### DIFF
--- a/dspace-api/src/main/java/org/dspace/identifier/DOIIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/DOIIdentifierProvider.java
@@ -180,6 +180,11 @@ public class DOIIdentifierProvider
                     + ", the DSO does not meet the conditions that the repository imposes to have doi");
             return null;
         }
+        if (doiFilterService.hasExternalDOI(dso)) {
+            log.info("Couldn't register doi for DSO with handle " + dso.getHandle()
+                + ", the DSO already has an external DOI.");
+            return null;
+        }
         String doi = mint(context, dso);
         // register tries to reserve doi if it's not already.
         // So we don't have to reserve it here.
@@ -196,6 +201,11 @@ public class DOIIdentifierProvider
         if (!doiFilterService.isEligibleDSO(dso)) {
             log.info("Couldn't register doi for DSO with handle " + dso.getHandle()
                     + ", the DSO does not meet the conditions that the repository imposes to have doi");
+            return;
+        }
+        if (doiFilterService.hasExternalDOI(dso)) {
+            log.info("Couldn't register doi for DSO with handle " + dso.getHandle()
+                + ", the DSO already has an external DOI.");
             return;
         }
         String doi = DOI.formatIdentifier(identifier);

--- a/dspace-api/src/main/java/org/dspace/identifier/DOIIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/DOIIdentifierProvider.java
@@ -316,6 +316,10 @@ public class DOIIdentifierProvider
     public void registerOnline(Context context, DSpaceObject dso, String identifier)
             throws IdentifierException, IllegalArgumentException, SQLException
     {
+        if (doiFilterService.hasExternalDOI(dso)) {
+            throw new DOIIdentifierException("Cannot register for new DOI when item "
+                    + "already has an external DOI.", DOIIdentifierException.FOREIGN_DOI);
+        }
         String doi = DOI.formatIdentifier(identifier);
         // get TableRow and ensure DOI belongs to dso regarding our db
         TableRow doiRow = loadOrCreateDOI(context, dso, doi);

--- a/dspace-api/src/main/java/org/dspace/identifier/doi/DOIConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/doi/DOIConsumer.java
@@ -91,7 +91,7 @@ public class DOIConsumer implements Consumer
         }
         catch (IdentifierNotFoundException ex)
         {
-            if ( doiFilterService.isEligibleDSO(dso)) {
+            if ( doiFilterService.isEligibleDSO(dso) && !doiFilterService.hasExternalDOI(dso)) {
                 log.warn("DOIConsumer cannot handles items without DOIs, skipping: "
                         + event.toString());
             }

--- a/dspace-api/src/main/java/org/dspace/identifier/doi/service/DOIFilterService.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/doi/service/DOIFilterService.java
@@ -11,5 +11,13 @@ public interface DOIFilterService {
      * @return false if the item does not apply any filters conditions. Else, return true.
      */
     public boolean isEligibleDSO(DSpaceObject dso);
+    
+    /**
+     * Determine if DSO has external DOI among it metadata. External DOIs are those that not match the
+     * DOI prefix of the repository (set at "identifier.doi.prefix").
+     * @param dso
+     * @return false if the item does not have external DOI. Else, return true.
+     */
+    public boolean hasExternalDOI(DSpaceObject dso);
 
 }

--- a/dspace/config/spring/api/identifier-service.xml
+++ b/dspace/config/spring/api/identifier-service.xml
@@ -51,6 +51,7 @@
          class="ar.edu.unlp.sedici.dspace.identifier.doi.service.DOIFilterServiceImpl"
          scope="singleton">
          <property name="mainFilter" ref="DOIMainFilter"/>
+         <property name="externalDOImetadata" value="sedici.identifier.other"/>
      </bean>
      
     <!-- Tendria que ser prototype este bean?? -->

--- a/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/identifier/doi/service/DOIFilterServiceImpl.java
+++ b/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/identifier/doi/service/DOIFilterServiceImpl.java
@@ -37,14 +37,16 @@ public class DOIFilterServiceImpl implements DOIFilterService {
         Metadatum[] metadataList = dso.getMetadataByMetadataString(this.externalDOImetadata);
         if (metadataList.length > 0) {
             for (Metadatum md : metadataList) {
-                try {
-                    String doi = DOI.formatIdentifier(md.value);
-                    if (!doi.isEmpty()) {
-                        //If metadata can be parsed, then it is an external DOI
-                        return true;
+                if (md.value != null && !md.value.isEmpty() && md.value.contains("doi")) {
+                    try {
+                        String doi = DOI.formatIdentifier(md.value);
+                        if (!doi.isEmpty()) {
+                            //If metadata can be parsed, then it is an external DOI
+                            return true;
+                        }
+                    } catch (DOIIdentifierException e) {
+                        //Do Nothing, proceed with next instance if available.
                     }
-                } catch (DOIIdentifierException e) {
-                    //Do Nothing, proceed with next instance if available.
                 }
             }
         }

--- a/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/identifier/doi/service/DOIFilterServiceImpl.java
+++ b/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/identifier/doi/service/DOIFilterServiceImpl.java
@@ -1,10 +1,10 @@
 package ar.edu.unlp.sedici.dspace.identifier.doi.service;
 
-import java.util.List;
 
 import org.dspace.content.DSpaceObject;
-import org.dspace.content.Item;
 import org.dspace.content.Metadatum;
+import org.dspace.identifier.DOI;
+import org.dspace.identifier.doi.DOIIdentifierException;
 import org.dspace.identifier.doi.service.DOIFilterService;
 import org.springframework.beans.factory.annotation.Required;
 
@@ -13,14 +13,45 @@ import ar.edu.unlp.sedici.dspace.identifier.doi.filters.AbstractDOIFilter;
 public class DOIFilterServiceImpl implements DOIFilterService {
 
     protected AbstractDOIFilter mainFilter;
+    /**
+     * Metadata holding any value of DOI external to this repository.
+     */
+    protected String externalDOImetadata;
     
     @Required
     public void setMainFilter(AbstractDOIFilter mainFilter) {
         this.mainFilter = mainFilter;
     }
+    
+    public void setExternalDOImetadata(String metadataName) {
+        this.externalDOImetadata = metadataName;
+    }
+    
     @Override
     public boolean isEligibleDSO(DSpaceObject dso) {
         return mainFilter.evaluate(dso);
     }
+    
+    @Override
+    public boolean hasExternalDOI(DSpaceObject dso) {
+        Metadatum[] metadataList = dso.getMetadataByMetadataString(this.externalDOImetadata);
+        if (metadataList.length > 0) {
+            for (Metadatum md : metadataList) {
+                try {
+                    String doi = DOI.formatIdentifier(md.value);
+                    if (!doi.isEmpty()) {
+                        //If metadata can be parsed, then it is an external DOI
+                        return true;
+                    }
+                } catch (DOIIdentifierException e) {
+                    //Do Nothing, proceed with next instance if available.
+                }
+            }
+        }
+        //if DSO has not any instance of externalDOIMetadata, then it has not external DOI.
+        return false;
+    }
+    
+    
     
 }


### PR DESCRIPTION
Se agregó una validación de la existencia de un DOI externo (principalmente guardado en el metadato 'sedici.identifier.other') al momento de ejecutar el método _#register()_ o _#registerOnline()_ en el DOIIdentifierProvider.java.

De esta manera, se evita que se creen tuplas innecesarias en la tabla 'doi' de items en la espera de registrarse (TO_BE_REGISTERED) cuando en realidad no es necesaria su registración por la existencia de otro identificador DOI externo al repositorio.