### PR TITLE
Cambio en los metadatos del formulario de submission

### DIFF
--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -528,10 +528,9 @@
 					<dc-schema>dc</dc-schema>
 					<dc-element>subject</dc-element>
 					<repeatable>true</repeatable>
-					<label>Palabras claves (*)</label>
+					<label>Palabras claves</label>
 					<input-type>onebox</input-type>
 					<hint>Descriptores</hint>
-					<visibility-on-group>Bibliotecarios</visibility-on-group>
 				</field>
 
 				<!-- Materia (categoria 5 del Tesauro) -->

--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -934,10 +934,20 @@
 					<label>Editorial</label>
 					<input-type>onebox</input-type>
 					<hint>Editorial encargada de la publicación de la obra</hint>
-					<type-bind>Tesis,Libro,Publicacion seriada</type-bind>
+					<type-bind>Tesis,Publicacion seriada</type-bind>
 					<visibility-on-group>Bibliotecarios</visibility-on-group>
 				</field>
-				
+				<!-- Editorial obligatorio para libros -->
+				<field>
+					<dc-schema>dc</dc-schema>
+					<dc-element>publisher</dc-element>
+					<label>Editorial (*)</label>
+					<input-type>onebox</input-type>
+					<hint>Editorial encargada de la publicación de la obra</hint>
+					<type-bind>Libro</type-bind>
+					<required-on-group>Bibliotecarios</required-on-group>
+					<visibility-on-group>Bibliotecarios</visibility-on-group>
+				</field>
 				<!-- Produccion -->
 				<field>
 					<dc-schema>dc</dc-schema>

--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -249,6 +249,7 @@
 					<dc-schema>sedici</dc-schema>
 					<dc-element>creator</dc-element>
 					<dc-qualifier>corporate</dc-qualifier>
+					<repeatable>true</repeatable>
 					<label>Autor Institucional</label>
 					<input-type>onebox</input-type>
 					<hint>Institución,empresa u organización creadora del recurso</hint>

--- a/dspace/config/modules/sedici-dspace.cfg
+++ b/dspace/config/modules/sedici-dspace.cfg
@@ -59,6 +59,7 @@ http://creativecommons.org/licenses/by-nd/4.0/ = Creative Commons Attribution-No
 http://creativecommons.org/licenses/by-sa/4.0/ =  Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0),\
 http://creativecommons.org/licenses/by/4.0/ = Creative Commons Attribution 4.0 International (CC BY 4.0),\
 http://creativecommons.org/publicdomain/mark/1.0/ = Creative Commons Public Domain Mark (PDM),\
+https://creativecommons.org/publicdomain/zero/1.0/deed.es = CC0 1.0 Universal (CC0 1.0) Dedicación de Dominio Público,\
 https://opendatacommons.org/licenses/odbl/1-0/ = Open Data Commons Open Database License (ODbL) v1.0,\
 https://opendatacommons.org/licenses/by/1-0/ = Open Data Commons Attribution License (ODC-By) v1.0,\
 https://opendatacommons.org/licenses/pddl/1-0/ = Open Data Commons Public Domain Dedication and License (PDDL) v1.0


### PR DESCRIPTION
Este PR contiene 4 sencillos cambios al formulario de submission:

**7083** --> El metadato dc.publisher ahora es obligatorio para los documentos de tipo Libro. Crossref requiere este metadato a la hora de generar DOIS para los libros, por eso es necesario que siempre esté.
**7060** --> Se hizo repetible el campo Autor Institucional, metadato sedici.creator.corporate. Puede pasar que haya un documento creado por más de una institucion.
**7126** --> Se agregó una nueva licencia, la cc0. URL y texto: https://creativecommons.org/publicdomain/zero/1.0/deed.es , CC0 1.0 Universal (CC0 1.0) Dedicación de Dominio Público. Esta licencia es de dominio publico y sirve para cualquier tipo de item. Por ahora solo está en el formulario "traditional" de submission, no en el de autoarchivo. Mas adelante veremos si es necesario agregarla al de autoarchivo, lo que pasa es que para que esto pase o bien habria que harcodearla en el codigo como están las de autoarchivo hasta ahora o bien refactorizar ese step para que levante las licencias desde la config, como lo hace el del form traditional.
**7070** --> Ahora el campo "Palabras Clave", dc.subject,  está disponible para los usuarios al momento de hacer autoarchivo. El metadato se dejó visible para todos los usuarios que autoarchiven, no solo para el grupo bibliotecarios, y se dejó como opcional en caso que haya algún usuario que no sepa bien que ingresar

Probar que los cambios efectivamente funcionen en el form de submisison.
