### PR TITLE
8298 Modifico el mapeo a crossref para que no se mapee los dois de identifier.other como doi

### DIFF
--- a/dspace/config/crosswalks/DIM2Crossref.xsl
+++ b/dspace/config/crosswalks/DIM2Crossref.xsl
@@ -832,17 +832,7 @@
 		<doi_data xmlns="http://www.crossref.org/schema/4.4.2">
 
 			<doi>
-				<!-- Solo seteo el doi si ya existe alguno en sedici.identifier.other, sino se setea uno nuevo despúes, por afuera del xsl -->
-				<xsl:if
-					test="dspace:field[@mdschema='sedici' and @element='identifier' and @qualifier='other'
-						and java:ar.edu.unlp.sedici.dspace.utils.Utils.isDoi(text())]">
-					<xsl:variable name="doi"
-					select="dspace:field[@mdschema='sedici' and @element='identifier' and @qualifier='other'
-						and java:ar.edu.unlp.sedici.dspace.utils.Utils.isDoi(text())]" />
-					<xsl:variable name="doiStartIndex"
-					select="string-length(substring-before($doi,'10.'))+1" />
-					<xsl:value-of select="substring($doi,$doiStartIndex)" />
-				</xsl:if>
+				<!-- No se setea aca el doi, sino que se setea uno nuevo despúes por afuera del xsl en el CrosrefConnector -->
 			</doi>
 
 			<timestamp>


### PR DESCRIPTION
Ahora se pueden agregar dois externos a items que ya tengan dois propios. 
Lo que no se puede registrar un doi propio cuando ya se tiene uno externo.

Habria que chequear que:

1. Al intentar registrar un DOI para un item que ya tiene doi externo en dc.identifier.other, el DoiIdentifierProvider no lo debería permitir. Se puede chequear esto en los logs en donde salta un mensaje que dice "Cannot register for new DOI when item already has an external DOI"
2. Al agregar un DOI externo, es decir un doi a dc.identifier.other, a un item que ya tiene un doi generado por nosotros, debería poder actualizarse ese item en Crossref sin problema
3. En todos los casos el doi externo no se debería mapear en los metadatos enviados a Crossref