### PR TITLE
8091 Anulo chequeo para el envio de mails para submission

### DIFF
--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowManager.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowManager.java
@@ -70,7 +70,7 @@ public class XmlWorkflowManager {
         grantSubmitterReadPolicies(context, myitem);
 
     	// Alert email should not be sent
-		noEMail.put(myitem.getID(), Boolean.TRUE);
+        noEMail.put(myitem.getID(), Boolean.TRUE);
         
     	context.turnOffAuthorisationSystem();
         Step firstStep = wf.getFirstStep();
@@ -207,7 +207,7 @@ public class XmlWorkflowManager {
      * @return whether the mail should be sent or not
      * @throws SQLException
      */
-    public static boolean shouldSendAlert(Context context, XmlWorkflowItem wfi, EPerson eperson) throws SQLException {
+    public static boolean shouldSendAlertToSubmitter(Context context, XmlWorkflowItem wfi, EPerson eperson) throws SQLException {
     	// Checks the ADMIN privilege on target collection for the scpeficied eperson or the current users if eperson is null
     	if(eperson == null) {
     		return !AuthorizeManager.isAdmin(context, wfi.getCollection());
@@ -589,7 +589,7 @@ public class XmlWorkflowManager {
         InstallItem.installItem(c, wfi);
 
 	        //Notify only when it is needed
-	        if(shouldSendAlert(c, wfi, wfi.getSubmitter()))
+	        if(shouldSendAlertToSubmitter(c, wfi, wfi.getSubmitter()))
 	        	notifyOfArchive(c, item, collection);
         }
 

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowManager.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowManager.java
@@ -69,9 +69,8 @@ public class XmlWorkflowManager {
         removeUserItemPolicies(context, myitem, myitem.getSubmitter());
         grantSubmitterReadPolicies(context, myitem);
 
-    	// Decides if the alert email should be sent 
-    	if(!shouldSendAlert(context, wfi, null))
-    		noEMail.put(myitem.getID(), Boolean.TRUE);
+    	// Alert email should not be sent
+		noEMail.put(myitem.getID(), Boolean.TRUE);
         
     	context.turnOffAuthorisationSystem();
         Step firstStep = wf.getFirstStep();


### PR DESCRIPTION
Cuando se ejecutaba [start](https://github.com/sedici/DSpace/blob/023a3bf46de9acc21b11db4d9bef11e80dbf014a/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowManager.java#L57) en [XmlWorkflowManager.java](https://github.com/sedici/DSpace/blob/023a3bf46de9acc21b11db4d9bef11e80dbf014a/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowManager.java) se consultaba si se debía enviar o no un mail en base a si el usuario es admin o no

https://github.com/sedici/DSpace/blob/37c44eed299a62064dc7fc0fbf4f8da3e8b740d7/xmlui/src/main/java/org/dspace/xmlworkflow/XmlWorkflowManager.java#L72-L73

Quité la condición para que se agregue el item a [noEMail](https://github.com/sedici/DSpace/blob/023a3bf46de9acc21b11db4d9bef11e80dbf014a/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowManager.java#L52)