### PR TITLE
Agrego metadato entidad origen a colecciones y comunidades

### DIFF
--- a/dspace-api/src/main/java/org/dspace/administer/StructBuilder.java
+++ b/dspace-api/src/main/java/org/dspace/administer/StructBuilder.java
@@ -144,6 +144,7 @@ public class StructBuilder
         communityMap.put("sidebar", "side_bar_text");
         
         collectionMap.put("name", "name");
+        collectionMap.put("entidad_origen", "entidad_origen");
         collectionMap.put("description", "short_description");
         collectionMap.put("intro", "introductory_text");
         collectionMap.put("copyright", "copyright_text");
@@ -530,6 +531,13 @@ public class StructBuilder
             nameElement.setText(collection.getMetadata("name"));
             element.addContent(nameElement);
             
+            if (collection.getMetadata("entidad_origen") != null)
+            {
+                Element entidadOrigenElement = new Element("entidadorigen");
+                entidadOrigenElement.setText(collection.getMetadata("entidad_origen"));
+                element.addContent(entidadOrigenElement);
+            }
+
             if (collection.getMetadata("short_description") != null)
             {
                 Element descriptionElement = new Element("description");

--- a/dspace-api/src/main/java/org/dspace/administer/StructBuilder.java
+++ b/dspace-api/src/main/java/org/dspace/administer/StructBuilder.java
@@ -138,6 +138,7 @@ public class StructBuilder
         
         // load the mappings into the member variable hashmaps
         communityMap.put("name", "name");
+        communityMap.put("entidad_origen", "entidad_origen");
         communityMap.put("description", "short_description");
         communityMap.put("intro", "introductory_text");
         communityMap.put("copyright", "copyright_text");
@@ -437,6 +438,13 @@ public class StructBuilder
             nameElement.setText(community.getMetadata("name"));
             element.addContent(nameElement);
             
+            if (community.getMetadata("entidad_origen") != null)
+            {
+                Element entidadOrigenElement = new Element("entidadorigen");
+                entidadOrigenElement.setText(community.getMetadata("entidad_origen"));
+                element.addContent(entidadOrigenElement);
+            }
+
             if (community.getMetadata("short_description") != null)
             {
                 Element descriptionElement = new Element("description");

--- a/dspace-api/src/main/java/org/dspace/content/Collection.java
+++ b/dspace-api/src/main/java/org/dspace/content/Collection.java
@@ -82,6 +82,7 @@ public class Collection extends DSpaceObject
     private Group admins;
 
     // Keys for accessing Collection metadata
+    public static final String ENTIDAD_ORIGEN = "entidad_origen";
     public static final String COPYRIGHT_TEXT = "copyright_text";
     public static final String INTRODUCTORY_TEXT = "introductory_text";
     public static final String SHORT_DESCRIPTION = "short_description";

--- a/dspace-api/src/main/java/org/dspace/content/Community.java
+++ b/dspace-api/src/main/java/org/dspace/content/Community.java
@@ -60,6 +60,7 @@ public class Community extends DSpaceObject
     private Group admins;
 
     // Keys for accessing Community metadata
+    public static final String ENTIDAD_ORIGEN = "entidad_origen";
     public static final String COPYRIGHT_TEXT = "copyright_text";
     public static final String INTRODUCTORY_TEXT = "introductory_text";
     public static final String SHORT_DESCRIPTION = "short_description";

--- a/dspace-api/src/main/java/org/dspace/content/DSpaceObject.java
+++ b/dspace-api/src/main/java/org/dspace/content/DSpaceObject.java
@@ -1356,6 +1356,8 @@ public abstract class DSpaceObject
 
     protected String[] getMDValueByLegacyField(String field){
         switch (field) {
+            case "entidad_origen":
+                return new String[]{"mods", "originInfo", "place"};
             case "introductory_text":
                 return new String[]{MetadataSchema.DC_SCHEMA, "description", null};
             case "short_description":

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/MODSDisseminationCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/MODSDisseminationCrosswalk.java
@@ -537,6 +537,7 @@ public class MODSDisseminationCrosswalk extends SelfNamedPlugin
     {
         List<Metadatum> metadata = new ArrayList<Metadatum>();
 
+        String entidad_origen = collection.getMetadata("entidad_origen");
         String description = collection.getMetadata("introductory_text");
         String description_abstract = collection
                 .getMetadata("short_description");
@@ -547,6 +548,18 @@ public class MODSDisseminationCrosswalk extends SelfNamedPlugin
         String rights = collection.getMetadata("copyright_text");
         String rights_license = collection.getMetadata("license");
         String title = collection.getMetadata("name");
+
+        if (entidad_origen != null)
+        {
+            Metadatum met_entidad_origen = createDCValue("entidad_origen", null, entidad_origen);
+            met_entidad_origen.schema = "mods";
+            metadata.add(met_entidad_origen);
+        }
+
+        if (description != null)
+        {
+            metadata.add(createDCValue("description", null, description));
+        }
 
         if (description != null)
         {

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/MODSDisseminationCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/MODSDisseminationCrosswalk.java
@@ -484,6 +484,7 @@ public class MODSDisseminationCrosswalk extends SelfNamedPlugin
     {
         List<Metadatum> metadata = new ArrayList<Metadatum>();
 
+        String entidad_origen = community.getMetadata("entidad_origen");
         String description = community.getMetadata("introductory_text");
         String description_abstract = community
                 .getMetadata("short_description");
@@ -493,6 +494,12 @@ public class MODSDisseminationCrosswalk extends SelfNamedPlugin
         String rights = community.getMetadata("copyright_text");
         String title = community.getMetadata("name");
 
+        if (entidad_origen != null)
+        {
+            Metadatum met_entidad_origen = createDCValue("entidad_origen", null, entidad_origen);
+            met_entidad_origen.schema = "mods";
+            metadata.add(met_entidad_origen);
+        }
         if (description != null)
         {
             metadata.add(createDCValue("description", null, description));
@@ -554,11 +561,6 @@ public class MODSDisseminationCrosswalk extends SelfNamedPlugin
             Metadatum met_entidad_origen = createDCValue("entidad_origen", null, entidad_origen);
             met_entidad_origen.schema = "mods";
             metadata.add(met_entidad_origen);
-        }
-
-        if (description != null)
-        {
-            metadata.add(createDCValue("description", null, description));
         }
 
         if (description != null)

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/XSLTDisseminationCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/XSLTDisseminationCrosswalk.java
@@ -334,7 +334,7 @@ public class XSLTDisseminationCrosswalk
             if (dso.getType() == Constants.COLLECTION)
             {
                 Collection collection = (Collection) dso;
-
+                String entidad_origen = collection.getMetadata("entidad_origen");
                 String description = collection.getMetadata("introductory_text");
                 String description_abstract = collection.getMetadata("short_description");
                 String description_table = collection.getMetadata("side_bar_text");
@@ -352,6 +352,8 @@ public class XSLTDisseminationCrosswalk
                 dim.addContent(createField("dc","rights",null,null,rights));
                 dim.addContent(createField("dc","rights","license",null,rights_license));
                 dim.addContent(createField("dc","title",null,null,title));
+                dim.addContent(createField("mods","originInfo","place",null,entidad_origen));
+
             }
             else if (dso.getType() == Constants.COMMUNITY)
             {

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/XSLTDisseminationCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/XSLTDisseminationCrosswalk.java
@@ -358,7 +358,7 @@ public class XSLTDisseminationCrosswalk
             else if (dso.getType() == Constants.COMMUNITY)
             {
                 Community community = (Community) dso;
-
+                String entidad_origen = community.getMetadata("entidad_origen");
                 String description = community.getMetadata("introductory_text");
                 String description_abstract = community.getMetadata("short_description");
                 String description_table = community.getMetadata("side_bar_text");
@@ -372,6 +372,7 @@ public class XSLTDisseminationCrosswalk
                 dim.addContent(createField("dc","identifier","uri",null,identifier_uri));
                 dim.addContent(createField("dc","rights",null,null,rights));
                 dim.addContent(createField("dc","title",null,null,title));
+                dim.addContent(createField("mods","originInfo","place",null,entidad_origen));
             }
             else if (dso.getType() == Constants.SITE)
             {

--- a/dspace-api/src/main/java/org/dspace/content/packager/PackageUtils.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/PackageUtils.java
@@ -62,6 +62,7 @@ public class PackageUtils
     {
         // getMetadata()  ->  DC element.term
         "name",                    "dc.title",
+        "entidad_origen",          "mods.originInfo.place",
         "introductory_text",       "dc.description",
         "short_description",       "dc.description.abstract",
         "side_bar_text",           "dc.description.tableofcontents",

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -836,6 +836,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
 
 
         // and populate it
+        String entidad_origen = collection.getMetadata("entidad_origen");
         String description = collection.getMetadata("introductory_text");
         String description_abstract = collection.getMetadata("short_description");
         String description_table = collection.getMetadata("side_bar_text");
@@ -852,6 +853,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
         addContainerMetadataField(doc, highlightedMetadataFields, toIgnoreMetadataFields, "dc.rights", rights);
         addContainerMetadataField(doc, highlightedMetadataFields, toIgnoreMetadataFields, "dc.rights.license", rights_license);
         addContainerMetadataField(doc, highlightedMetadataFields, toIgnoreMetadataFields, "dc.title", title);
+        addContainerMetadataField(doc, highlightedMetadataFields, toIgnoreMetadataFields, "mods.originInfo.place", entidad_origen);
 
 
         //Do any additional indexing, depends on the plugins

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -785,6 +785,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
         }
 
         // and populate it
+        String entidad_origen = community.getMetadata("entidad_origen");
         String description = community.getMetadata("introductory_text");
         String description_abstract = community.getMetadata("short_description");
         String description_table = community.getMetadata("side_bar_text");
@@ -797,6 +798,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
         addContainerMetadataField(doc, highlightedMetadataFields, toIgnoreMetadataFields, "dc.description.tableofcontents", description_table);
         addContainerMetadataField(doc, highlightedMetadataFields, toIgnoreMetadataFields, "dc.rights", rights);
         addContainerMetadataField(doc, highlightedMetadataFields, toIgnoreMetadataFields, "dc.title", title);
+        addContainerMetadataField(doc, highlightedMetadataFields, toIgnoreMetadataFields, "mods.originInfo.place", entidad_origen);
 
         //Do any additional indexing, depends on the plugins
         List<SolrServiceIndexPlugin> solrServiceIndexPlugins = new DSpace().getServiceManager().getServicesByType(SolrServiceIndexPlugin.class);

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowContainerUtils.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowContainerUtils.java
@@ -82,6 +82,7 @@ public class FlowContainerUtils
 		
 		// Get the metadata
 		String name = request.getParameter("name");
+		String entidadOrigen = request.getParameter("entidad_origen");
 		String shortDescription = request.getParameter("short_description");
 		String introductoryText = request.getParameter("introductory_text");
 		String copyrightText = request.getParameter("copyright_text");
@@ -96,6 +97,10 @@ public class FlowContainerUtils
         }
 
 		// If empty, make it null.
+		if (entidadOrigen != null && entidadOrigen.length() == 0)
+        {
+			entidadOrigen = null;
+        }
 		if (shortDescription != null && shortDescription.length() == 0)
         {
             shortDescription = null;
@@ -123,6 +128,7 @@ public class FlowContainerUtils
 		
 		// Save the metadata
 		collection.setMetadata("name", name);
+		collection.setMetadata("entidad_origen", entidadOrigen);
 		collection.setMetadata("short_description", shortDescription);
 		collection.setMetadata("introductory_text", introductoryText);
 		collection.setMetadata("copyright_text", copyrightText);
@@ -746,6 +752,7 @@ public class FlowContainerUtils
 		
 		// Get the metadata
 		String name = request.getParameter("name");
+		String entidadOrigen = request.getParameter("entidad_origen");
 		String shortDescription = request.getParameter("short_description");
 		String introductoryText = request.getParameter("introductory_text");
 		String copyrightText = request.getParameter("copyright_text");
@@ -760,6 +767,10 @@ public class FlowContainerUtils
         }
 
 		// If empty, make it null.
+		if (entidadOrigen != null && entidadOrigen.length() == 0)
+        {
+			entidadOrigen = null;
+        }
 		if (shortDescription != null && shortDescription.length() == 0)
         {
             shortDescription = null;
@@ -787,6 +798,7 @@ public class FlowContainerUtils
 		
 		// Save the metadata
 		newCollection.setMetadata("name", name);
+		newCollection.setMetadata("entidad_origen", entidadOrigen);
 		newCollection.setMetadata("short_description", shortDescription);
 		newCollection.setMetadata("introductory_text", introductoryText);
 		newCollection.setMetadata("copyright_text", copyrightText);

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowContainerUtils.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowContainerUtils.java
@@ -864,6 +864,7 @@ public class FlowContainerUtils
         }
 		
 		String name = request.getParameter("name");
+		String entidadOrigen = request.getParameter("entidad_origen");
 		String shortDescription = request.getParameter("short_description");
 		String introductoryText = request.getParameter("introductory_text");
 		String copyrightText = request.getParameter("copyright_text");
@@ -876,6 +877,10 @@ public class FlowContainerUtils
         }
 
 		// If empty, make it null.
+		if (entidadOrigen != null && entidadOrigen.length() == 0)
+        {
+			entidadOrigen = null;
+        }
 		if (shortDescription != null && shortDescription.length() == 0)
         {
             shortDescription = null;
@@ -894,6 +899,7 @@ public class FlowContainerUtils
         }
 		
 		newCommunity.setMetadata("name", name);
+		newCommunity.setMetadata("entidad_origen", entidadOrigen);
 		newCommunity.setMetadata("short_description", shortDescription);
 		newCommunity.setMetadata("introductory_text", introductoryText);
 		newCommunity.setMetadata("copyright_text", copyrightText);
@@ -943,6 +949,7 @@ public class FlowContainerUtils
 		Community community = Community.find(context, communityID);
 		
 		String name = request.getParameter("name");
+		String entidadOrigen = request.getParameter("entidad_origen");
 		String shortDescription = request.getParameter("short_description");
 		String introductoryText = request.getParameter("introductory_text");
 		String copyrightText = request.getParameter("copyright_text");
@@ -955,6 +962,10 @@ public class FlowContainerUtils
         }
 
 		// If empty, make it null.
+		if (entidadOrigen != null && entidadOrigen.length() == 0)
+        {
+			entidadOrigen = null;
+        }
 		if (shortDescription != null && shortDescription.length() == 0)
         {
             shortDescription = null;
@@ -974,6 +985,7 @@ public class FlowContainerUtils
 		
 		// Save the data
 		community.setMetadata("name", name);
+		community.setMetadata("entidad_origen", entidadOrigen);
 		community.setMetadata("short_description", shortDescription);
         community.setMetadata("introductory_text", introductoryText);
         community.setMetadata("copyright_text", copyrightText);

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/collection/CreateCollectionForm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/collection/CreateCollectionForm.java
@@ -37,6 +37,7 @@ public class CreateCollectionForm extends AbstractDSpaceTransformer
 	private static final Message T_main_head = message("xmlui.administrative.collection.CreateCollectionForm.main_head");
 	
 	private static final Message T_label_name = message("xmlui.administrative.collection.EditCollectionMetadataForm.label_name");
+	private static final Message T_label_entidad_origen= message("xmlui.administrative.collection.EditCollectionMetadataForm.label_entidad_origen");
 	private static final Message T_label_short_description = message("xmlui.administrative.collection.EditCollectionMetadataForm.label_short_description");
 	private static final Message T_label_introductory_text = message("xmlui.administrative.collection.EditCollectionMetadataForm.label_introductory_text");
 	private static final Message T_label_copyright_text = message("xmlui.administrative.collection.EditCollectionMetadataForm.label_copyright_text");
@@ -74,6 +75,11 @@ public class CreateCollectionForm extends AbstractDSpaceTransformer
 	    Text name = metadataList.addItem().addText("name");
         name.setAutofocus("autofocus");
 	    name.setSize(40);
+
+	    // collection entidad de origen
+	    metadataList.addLabel(T_label_entidad_origen);
+	    Text entidad_origen = metadataList.addItem().addText("entidad_origen");
+	    name.setSize(100);
 	    
 	    // short description
 	    metadataList.addLabel(T_label_short_description);

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/collection/EditCollectionMetadataForm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/collection/EditCollectionMetadataForm.java
@@ -49,7 +49,7 @@ public class EditCollectionMetadataForm extends AbstractDSpaceTransformer
     private static final Message T_main_head = message("xmlui.administrative.collection.EditCollectionMetadataForm.main_head");
 
     private static final Message T_label_name = message("xmlui.administrative.collection.EditCollectionMetadataForm.label_name");
-    private static final Message T_label_entidad_origen= message("xmlui.administrative.collection.EditCollectionMetadataForm.label_name", "Entidad origen");
+    private static final Message T_label_entidad_origen= message("xmlui.administrative.collection.EditCollectionMetadataForm.label_entidad_origen");
     private static final Message T_label_short_description = message("xmlui.administrative.collection.EditCollectionMetadataForm.label_short_description");
     private static final Message T_label_introductory_text = message("xmlui.administrative.collection.EditCollectionMetadataForm.label_introductory_text");
     private static final Message T_label_copyright_text = message("xmlui.administrative.collection.EditCollectionMetadataForm.label_copyright_text");

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/collection/EditCollectionMetadataForm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/collection/EditCollectionMetadataForm.java
@@ -49,6 +49,7 @@ public class EditCollectionMetadataForm extends AbstractDSpaceTransformer
     private static final Message T_main_head = message("xmlui.administrative.collection.EditCollectionMetadataForm.main_head");
 
     private static final Message T_label_name = message("xmlui.administrative.collection.EditCollectionMetadataForm.label_name");
+    private static final Message T_label_entidad_origen= message("xmlui.administrative.collection.EditCollectionMetadataForm.label_name", "Entidad origen");
     private static final Message T_label_short_description = message("xmlui.administrative.collection.EditCollectionMetadataForm.label_short_description");
     private static final Message T_label_introductory_text = message("xmlui.administrative.collection.EditCollectionMetadataForm.label_introductory_text");
     private static final Message T_label_copyright_text = message("xmlui.administrative.collection.EditCollectionMetadataForm.label_copyright_text");
@@ -114,7 +115,13 @@ public class EditCollectionMetadataForm extends AbstractDSpaceTransformer
 	    Text name = metadataList.addItem().addText("name");
 	    name.setSize(40);
 	    name.setValue(thisCollection.getMetadata("name"));
-	    
+
+	    // collection entidad de origen
+	    metadataList.addLabel(T_label_entidad_origen);
+	    Text entidad_origen = metadataList.addItem().addText("entidad_origen");
+	    entidad_origen.setValue(thisCollection.getMetadata("entidad_origen"));
+	    entidad_origen.setSize(100);
+
 	    // short description
 	    metadataList.addLabel(T_label_short_description);
 	    Text short_description = metadataList.addItem().addText("short_description");

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/community/CreateCommunityForm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/community/CreateCommunityForm.java
@@ -40,6 +40,7 @@ public class CreateCommunityForm extends AbstractDSpaceTransformer
 	private static final Message T_main_head_top = message("xmlui.administrative.community.CreateCommunityForm.main_head_top");
 
 	private static final Message T_label_name = message("xmlui.administrative.community.EditCommunityMetadataForm.label_name");
+	private static final Message T_label_entidad_origen= message("xmlui.administrative.community.EditCommunityMetadataForm.label_entidad_origen");
 	private static final Message T_label_short_description = message("xmlui.administrative.community.EditCommunityMetadataForm.label_short_description");
 	private static final Message T_label_introductory_text = message("xmlui.administrative.community.EditCommunityMetadataForm.label_introductory_text");
 	private static final Message T_label_copyright_text = message("xmlui.administrative.community.EditCommunityMetadataForm.label_copyright_text");
@@ -84,7 +85,12 @@ public class CreateCommunityForm extends AbstractDSpaceTransformer
 	    Text name = metadataList.addItem().addText("name");
 	    name.setSize(40);
         name.setAutofocus("autofocus");
-	    
+
+	    // collection entidad de origen
+	    metadataList.addLabel(T_label_entidad_origen);
+	    Text entidad_origen = metadataList.addItem().addText("entidad_origen");
+	    name.setSize(100);
+
 	    // short description
 	    metadataList.addLabel(T_label_short_description);
 	    Text short_description = metadataList.addItem().addText("short_description");

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/community/EditCommunityMetadataForm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/community/EditCommunityMetadataForm.java
@@ -47,6 +47,7 @@ public class EditCommunityMetadataForm extends AbstractDSpaceTransformer
     private static final Message T_main_head = message("xmlui.administrative.community.EditCommunityMetadataForm.main_head");
 
     private static final Message T_label_name = message("xmlui.administrative.community.EditCommunityMetadataForm.label_name");
+    private static final Message T_label_entidad_origen= message("xmlui.administrative.community.EditCommunityMetadataForm.label_entidad_origen");
     private static final Message T_label_short_description = message("xmlui.administrative.community.EditCommunityMetadataForm.label_short_description");
     private static final Message T_label_introductory_text = message("xmlui.administrative.community.EditCommunityMetadataForm.label_introductory_text");
     private static final Message T_label_copyright_text = message("xmlui.administrative.community.EditCommunityMetadataForm.label_copyright_text");
@@ -103,6 +104,12 @@ public class EditCommunityMetadataForm extends AbstractDSpaceTransformer
 	    name.setSize(40);
 	    name.setValue(thisCommunity.getMetadata("name"));
 	    
+	    // collection entidad de origen
+	    metadataList.addLabel(T_label_entidad_origen);
+	    Text entidad_origen = metadataList.addItem().addText("entidad_origen");
+	    entidad_origen.setValue(thisCommunity.getMetadata("entidad_origen"));
+	    entidad_origen.setSize(100);
+
 	    // short description
 	    metadataList.addLabel(T_label_short_description);
 	    Text short_description = metadataList.addItem().addText("short_description");

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/AbstractSearch.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/AbstractSearch.java
@@ -552,6 +552,7 @@ public abstract class AbstractSearch extends AbstractDSpaceTransformer implement
      */
 
     protected void renderCommunity(Community community, DiscoverResult.DSpaceObjectHighlightResult highlightedResults, org.dspace.app.xmlui.wing.element.List communityMetadata) throws WingException {
+        String entidad_origen = community.getMetadata("entidad_origen");
         String description = community.getMetadata("introductory_text");
         String description_abstract = community.getMetadata("short_description");
         String description_table = community.getMetadata("side_bar_text");
@@ -559,6 +560,10 @@ public abstract class AbstractSearch extends AbstractDSpaceTransformer implement
         String rights = community.getMetadata("copyright_text");
         String title = community.getMetadata("name");
 
+        if(StringUtils.isNotBlank(entidad_origen))
+        {
+            addMetadataField(highlightedResults, "mods.originInfo.place", communityMetadata.addList(community.getHandle() + ":mods.originInfo.place"), entidad_origen);
+        }
         if(StringUtils.isNotBlank(description))
         {
             addMetadataField(highlightedResults, "dc.description", communityMetadata.addList(community.getHandle() + ":dc.description"), description);

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/AbstractSearch.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/AbstractSearch.java
@@ -496,6 +496,7 @@ public abstract class AbstractSearch extends AbstractDSpaceTransformer implement
      */
     protected void renderCollection(Collection collection, DiscoverResult.DSpaceObjectHighlightResult highlightedResults, org.dspace.app.xmlui.wing.element.List collectionMetadata) throws WingException {
 
+        String entidad_origen = collection.getMetadata("entidad_origen");
         String description = collection.getMetadata("introductory_text");
         String description_abstract = collection.getMetadata("short_description");
         String description_table = collection.getMetadata("side_bar_text");
@@ -505,6 +506,10 @@ public abstract class AbstractSearch extends AbstractDSpaceTransformer implement
         String rights_license = collection.getMetadata("license");
         String title = collection.getMetadata("name");
 
+        if(StringUtils.isNotBlank(entidad_origen))
+        {
+            addMetadataField(highlightedResults, "mods.originInfo.place", collectionMetadata.addList(collection.getHandle() + ":mods.originInfo.place"), entidad_origen);
+        }
         if(StringUtils.isNotBlank(description))
         {
             addMetadataField(highlightedResults, "dc.description", collectionMetadata.addList(collection.getHandle() + ":dc.description"), description);

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/objectmanager/ContainerAdapter.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/objectmanager/ContainerAdapter.java
@@ -293,14 +293,16 @@ public class ContainerAdapter extends AbstractAdapter
             else if (dso.getType() == Constants.COMMUNITY) 
             {
                 Community community = (Community) dso;
-                
+
+                String entidad_origen = community.getMetadata("entidad_origen");
                 String description = community.getMetadata("introductory_text");
                 String description_abstract = community.getMetadata("short_description");
                 String description_table = community.getMetadata("side_bar_text");
                 String identifier_uri = "http://hdl.handle.net/" + community.getHandle();
                 String rights = community.getMetadata("copyright_text");
                 String title = community.getMetadata("name");
-                
+
+                createField("mods","originInfo","place",null,entidad_origen);
                 createField("dc","description",null,null,description);
                 createField("dc","description","abstract",null,description_abstract);
                 createField("dc","description","tableofcontents",null,description_table);

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/objectmanager/ContainerAdapter.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/objectmanager/ContainerAdapter.java
@@ -255,6 +255,7 @@ public class ContainerAdapter extends AbstractAdapter
             {
                 Collection collection = (Collection) dso;
                 
+                String entidad_origen = collection.getMetadata("entidad_origen");
                 String description = collection.getMetadata("introductory_text");
                 String description_abstract = collection.getMetadata("short_description");
                 String description_table = collection.getMetadata("side_bar_text");
@@ -264,6 +265,7 @@ public class ContainerAdapter extends AbstractAdapter
                 String rights_license = collection.getMetadata("license");
                 String title = collection.getMetadata("name");
                 
+                createField("mods","originInfo","place",null,entidad_origen);
                 createField("dc","description",null,null,description);
                 createField("dc","description","abstract",null,description_abstract);
                 createField("dc","description","tableofcontents",null,description_table);

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/utils/DSpaceValidity.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/utils/DSpaceValidity.java
@@ -255,6 +255,7 @@ public class DSpaceValidity implements SourceValidity
             
             validityKey.append("Collection:");
             validityKey.append(collection.getHandle());
+            validityKey.append(collection.getMetadata("entidad_origen"));
             validityKey.append(collection.getMetadata("introductory_text"));
             validityKey.append(collection.getMetadata("short_description"));
             validityKey.append(collection.getMetadata("side_bar_text"));

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/utils/DSpaceValidity.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/utils/DSpaceValidity.java
@@ -239,6 +239,7 @@ public class DSpaceValidity implements SourceValidity
 
             validityKey.append("Community:");
             validityKey.append(community.getHandle());
+            validityKey.append(community.getMetadata("entidad_origen"));
             validityKey.append(community.getMetadata("introductory_text"));
             validityKey.append(community.getMetadata("short_description"));
             validityKey.append(community.getMetadata("side_bar_text"));

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
@@ -1991,6 +1991,7 @@
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.main_head">Edit Metadata for Community {0}</message>
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.edit_authorizations">Edit authorization policies</message>
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_name">Name</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_entidad_origen">Belonging institution</message>
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_short_description">Short Description</message>
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_introductory_text">Introductory text (HTML)</message>
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_copyright_text">Copyright text (HTML)</message>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
@@ -1852,6 +1852,7 @@
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.trail">Metadata</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.main_head">Edit Collection: {0}</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_name">Name</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_entidad_origen">Belonging institution</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_short_description">Short Description</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_introductory_text">Introductory text (HTML)</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_copyright_text">Copyright text (HTML)</message>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages_es.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages_es.xml
@@ -1991,6 +1991,7 @@ Para asignar un item a esta colección, cerciórese de estar en la colección co
 <message key="xmlui.administrative.community.EditCommunityMetadataForm.main_head">Editar metadatos de la comunidad {0}</message>
 <message key="xmlui.administrative.community.EditCommunityMetadataForm.edit_authorizations">Editar privilegios</message>
 <message key="xmlui.administrative.community.EditCommunityMetadataForm.label_name">Nombre</message>
+<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_entidad_origen">Entidad de origen</message>
 <message key="xmlui.administrative.community.EditCommunityMetadataForm.label_short_description">Descripción breve</message>
 <message key="xmlui.administrative.community.EditCommunityMetadataForm.label_introductory_text">Texto introductorio (HTML)</message>
 <message key="xmlui.administrative.community.EditCommunityMetadataForm.label_copyright_text">Texto de copyright (HTML)</message>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages_es.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages_es.xml
@@ -1852,6 +1852,7 @@ Para asignar un item a esta colección, cerciórese de estar en la colección co
 <message key="xmlui.administrative.collection.EditCollectionMetadataForm.trail">Metadatos</message>
 <message key="xmlui.administrative.collection.EditCollectionMetadataForm.main_head">Editar colección: {0}</message>
 <message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_name">Nombre</message>
+<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_entidad_origen">Entidad de origen</message>
 <message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_short_description">Descripción breve:</message>
 <message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_introductory_text">Texto introductorio (HTML)</message>
 <message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_copyright_text">Texto de copyright (texto plano)</message>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages_pt_BR.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages_pt_BR.xml
@@ -1816,6 +1816,7 @@
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.main_head">Edição de metadado para a comunidade {0}</message>
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.edit_authorizations">Edição de políticas de autorização</message>
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_name">Nome</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_entidad_origen">Instituição de origem</message>
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_short_description">Pequena descrição</message>
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_introductory_text">Texto introdutório (HTML)</message>
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_copyright_text">Texto sobre os direitos autorais (HTML)</message>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages_pt_BR.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages_pt_BR.xml
@@ -1677,6 +1677,7 @@
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.trail">Metadado</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.main_head">Editar coleção: {0}</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_name">Nome</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_entidad_origen">Instituição de origem</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_short_description">Pequena descrição</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_introductory_text">Texto introdutório (HTML)</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_copyright_text">Texto sobre os direitos autorais (HTML)</message>

--- a/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/xsl/aspect/artifactbrowser/collection-view-append.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/xsl/aspect/artifactbrowser/collection-view-append.xsl
@@ -133,7 +133,7 @@
        
     <!-- Generate the info about the collection from the metadata section -->
     <xsl:template match="dim:dim" mode="collectionDetailView-DIM">
-        <xsl:if test="string-length(dim:field[@element='description'][not(@qualifier)])&gt;0">
+        <xsl:if test="string-length(dim:field[@element='description'][not(@qualifier)])&gt;0 or string-length(dim:field[@mdschema='mods'][@element='originInfo'][@qualifier='place'])&gt;0">
             <div class="intro-text">
                 <xsl:if test="string-length(dim:field[@mdschema='mods'][@element='originInfo'][@qualifier='place'])&gt;0">
                     <div>
@@ -145,9 +145,11 @@
                         </span>
                     </div>
                 </xsl:if>
-                <xsl:call-template name="parseCommunityCollectionMetadata">
-            		<xsl:with-param name="node" select="dim:field[@element='description'][not(@qualifier)]/node()"/>
-            	</xsl:call-template>
+                <xsl:if test="string-length(dim:field[@element='description'][not(@qualifier)])&gt;0">
+                    <xsl:call-template name="parseCommunityCollectionMetadata">
+                        <xsl:with-param name="node" select="dim:field[@element='description'][not(@qualifier)]/node()"/>
+                    </xsl:call-template>
+                </xsl:if>
             </div>
         </xsl:if>
 

--- a/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/xsl/aspect/artifactbrowser/collection-view-append.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/xsl/aspect/artifactbrowser/collection-view-append.xsl
@@ -135,6 +135,16 @@
     <xsl:template match="dim:dim" mode="collectionDetailView-DIM">
         <xsl:if test="string-length(dim:field[@element='description'][not(@qualifier)])&gt;0">
             <div class="intro-text">
+                <xsl:if test="string-length(dim:field[@mdschema='mods'][@element='originInfo'][@qualifier='place'])&gt;0">
+                    <div>
+                        <span class="label">
+                            <i18n:text>xmlui.administrative.collection.EditCollectionMetadataForm.label_entidad_origen</i18n:text>:
+                        </span>
+                        <span class="value">
+                            <xsl:copy-of select="dim:field[@mdschema='mods'][@element='originInfo'][@qualifier='place']/node()" />
+                        </span>
+                    </div>
+                </xsl:if>
                 <xsl:call-template name="parseCommunityCollectionMetadata">
             		<xsl:with-param name="node" select="dim:field[@element='description'][not(@qualifier)]/node()"/>
             	</xsl:call-template>

--- a/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/xsl/aspect/artifactbrowser/community-view-append.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/xsl/aspect/artifactbrowser/community-view-append.xsl
@@ -143,11 +143,23 @@
 
     <!-- Generate the info about the community from the metadata section -->
     <xsl:template match="dim:dim" mode="communityDetailView-DIM">
-        <xsl:if test="string-length(dim:field[@element='description'][not(@qualifier)])&gt;0">
+        <xsl:if test="string-length(dim:field[@element='description'][not(@qualifier)])&gt;0 or string-length(dim:field[@mdschema='mods'][@element='originInfo'][@qualifier='place'])&gt;0">
             <div class="intro-text">
-            	<xsl:call-template name="parseCommunityCollectionMetadata">
-            		<xsl:with-param name="node" select="dim:field[@element='description'][not(@qualifier)]/node()"/>
-            	</xsl:call-template>
+                <xsl:if test="string-length(dim:field[@mdschema='mods'][@element='originInfo'][@qualifier='place'])&gt;0">
+                    <div>
+                        <span class="label">
+                            <i18n:text>xmlui.administrative.community.EditCommunityMetadataForm.label_entidad_origen</i18n:text>:
+                        </span>
+                        <span class="value">
+                            <xsl:copy-of select="dim:field[@mdschema='mods'][@element='originInfo'][@qualifier='place']/node()" />
+                        </span>
+                    </div>
+                </xsl:if>
+                <xsl:if test="string-length(dim:field[@element='description'][not(@qualifier)])&gt;0">
+                    <xsl:call-template name="parseCommunityCollectionMetadata">
+                        <xsl:with-param name="node" select="dim:field[@element='description'][not(@qualifier)]/node()"/>
+                    </xsl:call-template>
+                </xsl:if>
             </div>
         </xsl:if>
 


### PR DESCRIPTION
Cambio código de DSpace para agregar el metadato en las pantallas de edición, creación y vista de comunidades y colecciones.
El metadato que se utilizó es el mods.originInfo.place

Habría que probar agregar este metadato a un par de comunidades y colecciones y luego probar que se vea y se guarde correctamente.