### PR TITLE
7002 Se habilitó "useProxies" para registrar descargas en Google Analytics

### DIFF
--- a/dspace-api/src/main/java/org/dspace/google/GoogleRecorderEventListener.java
+++ b/dspace-api/src/main/java/org/dspace/google/GoogleRecorderEventListener.java
@@ -8,6 +8,8 @@
 
 package org.dspace.google;
 
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -18,6 +20,7 @@ import org.apache.http.message.BasicNameValuePair;
 import org.apache.log4j.Logger;
 import org.dspace.core.Constants;
 import org.dspace.services.model.Event;
+import org.dspace.statistics.util.IPTable;
 import org.dspace.usage.AbstractUsageEventListener;
 import org.dspace.usage.UsageEvent;
 import org.dspace.utils.DSpace;
@@ -42,10 +45,14 @@ public class GoogleRecorderEventListener extends AbstractUsageEventListener {
     private String GoogleURL = "https://www.google-analytics.com/collect";
     private static Logger log = Logger.getLogger(GoogleRecorderEventListener.class);
 
+    private Boolean useProxiesEnabled;
+    private static final String X_FORWARDED_FOR_HEADER = "X-Forwarded-For";
+    private IPTable trustedProxies;
 
     public GoogleRecorderEventListener() {
         // httpclient is threadsafe so we only need one.
         httpclient = HttpClients.createDefault();
+        trustedProxies = parseTrustedProxyRanges(StringUtils.stripAll(new DSpace().getConfigurationService().getPropertyAsType("proxies.trusted.ipranges", String[].class)));
     }
 
     public void receiveEvent(Event event) {
@@ -73,12 +80,12 @@ public class GoogleRecorderEventListener extends AbstractUsageEventListener {
             }
         }
     }
-
     private void bitstreamDownload(UsageEvent ue) throws IOException {
         HttpPost httpPost = new HttpPost(GoogleURL);
 
         List<NameValuePair> nvps = new ArrayList<NameValuePair>();
         nvps.add(new BasicNameValuePair("v", "1"));
+        nvps.add(new BasicNameValuePair("uip", getClientIp(ue.getRequest().getRemoteAddr(), ue.getRequest().getHeader(X_FORWARDED_FOR_HEADER))));
         nvps.add(new BasicNameValuePair("tid", analyticsKey));
         nvps.add(new BasicNameValuePair("cid", "999"));
         nvps.add(new BasicNameValuePair("t", "event"));
@@ -94,5 +101,88 @@ public class GoogleRecorderEventListener extends AbstractUsageEventListener {
 
         log.debug("Posted to Google Analytics - " + ue.getRequest().getRequestURI());
     }
+
+//  Por lo comentado en http://trac.prebi.unlp.edu.ar/issues/7002
+//  es necesario chequear la IP del cliente y ver si en el "X-Forwarder-For" hay algún proxy confiable
+//  Este código esta copiado de los servicios implementados para D6 y D7 https://github.com/DSpace/DSpace/blob/2d5eafb384abb94058ce080c86250fb09f029cca/dspace-api/src/main/java/org/dspace/service/impl/ClientInfoServiceImpl.java#L53
+//  Descartar este código al migrar a D7 y llamar al servicio correspondiente
+    public String getClientIp(String remoteIp, String xForwardedForHeaderValue) {
+        String ip = remoteIp;
+
+        if (isUseProxiesEnabled()) {
+            String xForwardedForIp = getXForwardedForIpValue(remoteIp, xForwardedForHeaderValue);
+
+            if (StringUtils.isNotBlank(xForwardedForIp) && isRequestFromTrustedProxy(ip)) {
+                ip = xForwardedForIp;
+            }
+
+        } else if (StringUtils.isNotBlank(xForwardedForHeaderValue)) {
+            log.warn(
+                    "X-Forwarded-For header detected but useProxiesEnabled is not enabled. " +
+                            "If your dspace is behind a proxy set it to true");
+        }
+
+        return ip;
+
+    }
+
+    private String getXForwardedForIpValue(String remoteIp, String xForwardedForValue) {
+        String ip = null;
+
+        /* This header is a comma delimited list */
+        String headerValue = StringUtils.trimToEmpty(xForwardedForValue);
+        for (String xfip : headerValue.split(",")) {
+            /* proxy itself will sometime populate this header with the same value in
+               remote address. ordering in spec is vague, we'll just take the last
+               not equal to the proxy
+            */
+            if (!StringUtils.equals(remoteIp, xfip) && StringUtils.isNotBlank(xfip)
+                    //if we have trusted proxies, we'll assume that they are not the client IP
+                    && (trustedProxies == null || !isRequestFromTrustedProxy(xfip))) {
+
+                ip = xfip.trim();
+            }
+        }
+
+        return ip;
+    }
+
+    private boolean isRequestFromTrustedProxy(String ipAddress) {
+        try {
+            return trustedProxies == null || trustedProxies.contains(ipAddress);
+        } catch (IPTable.IPFormatException e) {
+            log.error("Request contains invalid remote address", e);
+            return false;
+        }
+    }
+
+    private IPTable parseTrustedProxyRanges(String[] proxyProperty) {
+        if (ArrayUtils.isEmpty(proxyProperty)) {
+            return null;
+        } else {
+            //Load all supplied proxy IP ranges into the IP table
+            IPTable ipTable = new IPTable();
+            try {
+                for (String proxyRange : proxyProperty) {
+                    ipTable.add(proxyRange);
+                }
+            } catch (IPTable.IPFormatException e) {
+                log.error("Property proxies.trusted.ipranges contains an invalid IP range", e);
+                ipTable = null;
+            }
+
+            return ipTable;
+        }
+    }
+
+    public boolean isUseProxiesEnabled() {
+            if (useProxiesEnabled == null) {
+                useProxiesEnabled = new DSpace().getConfigurationService().getPropertyAsType("useProxies", Boolean.class);
+                log.info("useProxies=" + useProxiesEnabled);
+            }
+
+            return useProxiesEnabled;
+        }
+
 
 }

--- a/dspace-api/src/main/java/org/dspace/google/GoogleRecorderEventListener.java
+++ b/dspace-api/src/main/java/org/dspace/google/GoogleRecorderEventListener.java
@@ -136,11 +136,12 @@ public class GoogleRecorderEventListener extends AbstractUsageEventListener {
                remote address. ordering in spec is vague, we'll just take the last
                not equal to the proxy
             */
+            xfip = xfip.trim();
             if (!StringUtils.equals(remoteIp, xfip) && StringUtils.isNotBlank(xfip)
                     //if we have trusted proxies, we'll assume that they are not the client IP
                     && (trustedProxies == null || !isRequestFromTrustedProxy(xfip))) {
 
-                ip = xfip.trim();
+                ip = xfip;
             }
         }
 

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -230,7 +230,16 @@ log.dir = ${dspace.dir}/log
 
 # If enabled, the logging and the Solr statistics system will look for
 # an X-Forwarded-For header. If it finds it, it will use this for the user IP address
-#useProxies = true
+useProxies = true
+
+# If "useProxies" is enabled, the authentication and statistics logging code will read the X-Forwarded-For header in
+# order to determine the correct client IP address. But they will only use that header value when the request is coming
+# from a trusted proxy server location (e.g. HTTPD on localhost). Leave this property empty to trust X-Forwarded-For
+# values of all requests. You can specify a range by only listing the first three ip-address blocks, e.g. 128.177.243
+# You can list multiple IP addresses or ranges by comma-separating them.
+# If you are running REST & UI on different servers, you should add the UI servers (range) as a proxy.
+# For example : proxies.trusted.ipranges = 127.0.0.1, 192.168.2
+proxies.trusted.ipranges = 127.0.0.1,192.168.2,163.10.34.147
 
 ##### DOI registration agency credentials ######
 # To mint DOIs you have to use a DOI registration agency like DataCite. Several

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -239,7 +239,7 @@ useProxies = true
 # You can list multiple IP addresses or ranges by comma-separating them.
 # If you are running REST & UI on different servers, you should add the UI servers (range) as a proxy.
 # For example : proxies.trusted.ipranges = 127.0.0.1, 192.168.2
-proxies.trusted.ipranges = 127.0.0.1,192.168.2,163.10.34.147
+proxies.trusted.ipranges = 127.0.0.1,163.10.34.147
 
 ##### DOI registration agency credentials ######
 # To mint DOIs you have to use a DOI registration agency like DataCite. Several


### PR DESCRIPTION
 Se registran las descargas a partir de la última IP, que no sea la de un proxy conocido, a paritir de las IPs que vienen en el X-Forwarded-For.  

El código agregado esta basado en DSpace 6. Hay un comentario para borrar ese código cuando se migre.

Para probar, uno puedo ejecutar
```curl --output tmp.pdf --header "User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.2; en-US; rv:1.9.0.1) Gecko/2008070208 Firefox/3.0.1" --header "X-Forwarded-For: 172.19.0.5, 163.10.34.147" -v  http://localhost:9090/bitstream/handle/10915/33046/.pdf?sequence=4&isAllowed=y&aux=o```

Previamente habría que agregar la IP de uno a dspace.cfg en "proxies.trusted.ipranges", como si uno fuese el proxy que hace la petición a DSpace. 
Verificar tambien que el pdf exista (en el ejemplo que pase es justamente un ejemplo)

Para el ejemplo anterior, la IP que se deberia agregar en el evento de GA en https://github.com/sedici/DSpace/blob/e6904c644c402620fdc848f6da499c545b3fd2d6/dspace-api/src/main/java/org/dspace/google/GoogleRecorderEventListener.java#L88 deberia ser "172.19.0.5"