### PR TITLE
7062 Agrego envío de dimension a analytics para registrar la coleccion padre del item

### DIFF
--- a/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/xsl/core/page-structure.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/xsl/core/page-structure.xsl
@@ -649,8 +649,12 @@ placeholders for header images -->
 						ga('set', 'dimension3', itemType);
 						ga('set', 'dimension5', itemSubtype);
 						ga('set', 'dimension6', itemDateIssued);
-						ga('set', 'dimension7', itemParentCollection);
-					</xsl:text>
+						</xsl:text>
+						<xsl:variable name="dsoParentHandle">
+							<xsl:value-of select="substring-after(/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='focus'][@qualifier='container']/text(), 'hdl:')"/>
+						</xsl:variable><xsl:text>
+						ga('set', 'dimension7', '</xsl:text><xsl:value-of select="$dsoParentHandle"/><xsl:text>');
+						</xsl:text>
 					</xsl:if>
 				</xsl:if><xsl:text>
 				ga('send', 'pageview');

--- a/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/xsl/core/page-structure.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/Sedici2/lib/xsl/core/page-structure.xsl
@@ -645,9 +645,11 @@ placeholders for header images -->
 						var itemType = document.getElementsByName("DC.type")[0].content;
 						var itemSubtype = document.getElementsByName("DC.type")[1].content;
 						var itemDateIssued = (document.getElementsByName("DCTERMS.issued")[0])? document.getElementsByName("DCTERMS.issued")[0].content : document.getElementsByName("DCTERMS.created")[0].content.substring(0,10);
+						var itemParentCollection = document.getElementById("ds-trail").querySelectorAll('.ds-trail-link:last-child')[0].firstElementChild.getAttribute('href').split('/handle/').pop();
 						ga('set', 'dimension3', itemType);
 						ga('set', 'dimension5', itemSubtype);
 						ga('set', 'dimension6', itemDateIssued);
+						ga('set', 'dimension7', itemParentCollection);
 					</xsl:text>
 					</xsl:if>
 				</xsl:if><xsl:text>


### PR DESCRIPTION
Saco el handle de la coleccion padre a partir del trail de objetos padre del DOM con js:

![image](https://user-images.githubusercontent.com/26695177/202210365-c0e73db8-45de-44d2-bfe2-011489fc05ef.png)

![image](https://user-images.githubusercontent.com/26695177/202210526-59211dbb-2e36-4180-aab3-e5c248c09174.png)

Habría que probar que el handle se envíe bien a analytics, para eso hay que configurar en el build properties la propiedad xmlui.google.analytics.key con el UA correspondiente y luego en el navegador entrar un item y ver si se hace un POST a analytics con todas las dimensiones bien seteadas