### PR TITLE
Ignoro valores con autohority para sedici.creator.* y sedici.contributor.*

### DIFF
--- a/dspace/config/modules/discovery.cfg
+++ b/dspace/config/modules/discovery.cfg
@@ -24,5 +24,9 @@ index.projection=dc.title,dc.contributor.*,dc.date.issued
 #	 Processors plugin in the dspace.cfg
 
 index.authority.ignore.dc.subject=true
-index.authority.ignore.sedici.creator.*=true
-index.authority.ignore.sedici.contributor.*=true
+index.authority.ignore.sedici.creator.person=true
+index.authority.ignore.sedici.creator.corporate=true
+index.authority.ignore.sedici.contributor.translator=true
+index.authority.ignore.sedici.contributor.compiler=true
+index.authority.ignore.sedici.contributor.editor=true
+index.authority.ignore.sedici.creator.interprete=true

--- a/dspace/config/modules/discovery.cfg
+++ b/dspace/config/modules/discovery.cfg
@@ -24,3 +24,5 @@ index.projection=dc.title,dc.contributor.*,dc.date.issued
 #	 Processors plugin in the dspace.cfg
 
 index.authority.ignore.dc.subject=true
+index.authority.ignore.sedici.creator.*=true
+index.authority.ignore.sedici.contributor.*=true


### PR DESCRIPTION
De esta forma se evita que en los facets se formen links a discovery que busquen a partir de la clave de una autoridad. Ahora los facets para sedici.creator.* y sedici.contributor.* se forman a partir del texto almacenado en los metadatos