### PR TITLE
6342-Cambio un paramtro de dspace.cfg

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1653,8 +1653,8 @@ websvc.opensearch.formats = atom,rss
 # Use -1 to force all bitstream to be served inline
 # The 'webui.*' setting is for the JSPUI, and
 # the 'xmlui.*' setting is for the XMLUI
-webui.content_disposition_threshold = 15000000
-xmlui.content_disposition_threshold = 15000000
+webui.content_disposition_threshold = 20000000
+xmlui.content_disposition_threshold = 20000000
 
 
 #### Multi-file HTML document/site settings #####

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1653,8 +1653,8 @@ websvc.opensearch.formats = atom,rss
 # Use -1 to force all bitstream to be served inline
 # The 'webui.*' setting is for the JSPUI, and
 # the 'xmlui.*' setting is for the XMLUI
-webui.content_disposition_threshold = 8388608
-xmlui.content_disposition_threshold = 8388608
+webui.content_disposition_threshold = 15000000
+xmlui.content_disposition_threshold = 15000000
 
 
 #### Multi-file HTML document/site settings #####


### PR DESCRIPTION
Cambie el limite de tamaño para abrir pdf en sedici de 8mb a 15mb. El parametro xmlui.content_disposition_threshold es usado en la linea 620 de [BitstreamReader](https://github.com/sedici/DSpace/blob/e4ac67cbd58996229dce349355311d52b8b33b97/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/BitstreamReader.java)
Resuelve el ticket: http://trac.prebi.unlp.edu.ar/issues/6342