### PR TITLE
Agregar translator o mas a la configuracion del browse

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1265,7 +1265,7 @@ webui.strengths.show = false
 #
 # For compatibility with previous versions:
 #
-webui.browse.index.1 = author:metadataAuthority:sedici.creator.person:authority
+webui.browse.index.1 = author:metadataAuthority:sedici.creator.person,sedici.contributor.translator:authority
 webui.browse.index.2 = subject:metadataAuthority:sedici.subject.materias:authority
 
 ## example of authority-controlled browse category - see authority control config

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1265,7 +1265,7 @@ webui.strengths.show = false
 #
 # For compatibility with previous versions:
 #
-webui.browse.index.1 = author:metadataAuthority:sedici.creator.person,sedici.contributor.translator:authority
+webui.browse.index.1 = author:metadataAuthority:sedici.creator.person,sedici.creator.corporate,sedici.contributor.translator,sedici.contributor.compiler,sedici.contributor.editor,sedici.creator.interprete:authority
 webui.browse.index.2 = subject:metadataAuthority:sedici.subject.materias:authority
 
 ## example of authority-controlled browse category - see authority control config


### PR DESCRIPTION
En el [ticket 8583](http://trac.prebi.unlp.edu.ar/issues/8583) expresan que estaria bueno cuando se navega por autores, aparezcan tambien sus traducciones.
Para hacer esto se agrega en la linea [1268](https://github.com/sedici/DSpace/blob/75d260eb97858908dda356cb9db461d9ebcf9ac8/dspace/config/dspace.cfg#L1268) el metadato que se quiera agregar