### PR TITLE
10113 arreglo mapeo thesis.degree.* a OAI

### DIFF
--- a/dspace/config/crosswalks/oai/metadataFormats/oai_dc.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/oai_dc.xsl
@@ -178,10 +178,10 @@
 			<!--No lo pongo -->
 			
 			<!-- thesis.degree.(name|grantor) =description -->
-			<xsl:for-each select="doc:metadata/doc:element[@name='tesis']/doc:element[@name='degree']/doc:element[@name='name']/doc:element/doc:field[@name='value']">
+			<xsl:for-each select="doc:metadata/doc:element[@name='thesis']/doc:element[@name='degree']/doc:element[@name='name']/doc:element/doc:field[@name='value']">
 				<dc:description><xsl:value-of select="." /></dc:description>
 			</xsl:for-each>
-			<xsl:for-each select="doc:metadata/doc:element[@name='tesis']/doc:element[@name='degree']/doc:element[@name='name']/doc:element/doc:field[@name='value']">
+			<xsl:for-each select="doc:metadata/doc:element[@name='thesis']/doc:element[@name='degree']/doc:element[@name='grantor']/doc:element/doc:field[@name='value']">
 				<dc:description><xsl:value-of select="." /></dc:description>
 			</xsl:for-each>
 			


### PR DESCRIPTION
De acuerdo a las directrices del SNRD, se mapea thesis.degree.grantor. También modifico el thesis.degree.name que no estaba funcionando