### PR TITLE
14056 Facet de filtro por fecha de publicacion no es consistente con el orden que se aplica despues (SEDICI 9.3)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/indexobject/ItemIndexFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/indexobject/ItemIndexFactoryImpl.java
@@ -84,6 +84,9 @@ public class ItemIndexFactoryImpl extends DSpaceObjectIndexFactoryImpl<Indexable
     public static final String STORE_SEPARATOR = "\n|||\n";
     public static final String STATUS_FIELD = "database_status";
     public static final String STATUS_FIELD_PREDB = "predb";
+    private static final String DATE_ISSUED_OR_CREATED_SORT_FIELD = "dc.date.issued_or_created";
+    private static final String DATE_ISSUED_FIELD = "dc.date.issued";
+    private static final String DATE_CREATED_FIELD = "dc.date.created";
 
 
     @Autowired
@@ -565,6 +568,7 @@ public class ItemIndexFactoryImpl extends DSpaceObjectIndexFactoryImpl<Indexable
                     "Item identifier: " + item.getID()), e);
         }
 
+        addIssuedOrCreatedSortField(doc, item);
 
         log.debug("  Added Metadata");
 
@@ -590,6 +594,41 @@ public class ItemIndexFactoryImpl extends DSpaceObjectIndexFactoryImpl<Indexable
 
 
         log.debug("  Added Grouping");
+    }
+
+    private void addIssuedOrCreatedSortField(SolrInputDocument doc, Item item) {
+        ZonedDateTime sortDate = null;
+
+        List<MetadataValue> issuedValues = itemService.getMetadataByMetadataString(item, DATE_ISSUED_FIELD);
+        if (issuedValues != null) {
+            sortDate = firstParsableDate(issuedValues);
+        }
+
+        if (sortDate == null) {
+            List<MetadataValue> createdValues = itemService.getMetadataByMetadataString(item, DATE_CREATED_FIELD);
+            if (createdValues != null) {
+                sortDate = firstParsableDate(createdValues);
+            }
+        }
+
+        if (sortDate != null) {
+            doc.addField(DATE_ISSUED_OR_CREATED_SORT_FIELD + "_dt", SolrUtils.getDateFormatter().format(sortDate));
+        }
+    }
+
+    private ZonedDateTime firstParsableDate(List<MetadataValue> metadataValues) {
+        for (MetadataValue metadataValue : metadataValues) {
+            if (metadataValue == null || StringUtils.isBlank(metadataValue.getValue())) {
+                continue;
+            }
+
+            ZonedDateTime parsedDate = MultiFormatDateParser.parse(metadataValue.getValue());
+            if (parsedDate != null) {
+                return parsedDate;
+            }
+        }
+
+        return null;
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/discovery/indexobject/ItemIndexFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/indexobject/ItemIndexFactoryImpl.java
@@ -84,10 +84,6 @@ public class ItemIndexFactoryImpl extends DSpaceObjectIndexFactoryImpl<Indexable
     public static final String STORE_SEPARATOR = "\n|||\n";
     public static final String STATUS_FIELD = "database_status";
     public static final String STATUS_FIELD_PREDB = "predb";
-    private static final String DATE_ISSUED_OR_CREATED_SORT_FIELD = "dc.date.issued_or_created";
-    private static final String DATE_ISSUED_FIELD = "dc.date.issued";
-    private static final String DATE_CREATED_FIELD = "dc.date.created";
-
 
     @Autowired
     protected HandleService handleService;
@@ -568,8 +564,6 @@ public class ItemIndexFactoryImpl extends DSpaceObjectIndexFactoryImpl<Indexable
                     "Item identifier: " + item.getID()), e);
         }
 
-        addIssuedOrCreatedSortField(doc, item);
-
         log.debug("  Added Metadata");
 
         try {
@@ -594,41 +588,6 @@ public class ItemIndexFactoryImpl extends DSpaceObjectIndexFactoryImpl<Indexable
 
 
         log.debug("  Added Grouping");
-    }
-
-    private void addIssuedOrCreatedSortField(SolrInputDocument doc, Item item) {
-        ZonedDateTime sortDate = null;
-
-        List<MetadataValue> issuedValues = itemService.getMetadataByMetadataString(item, DATE_ISSUED_FIELD);
-        if (issuedValues != null) {
-            sortDate = firstParsableDate(issuedValues);
-        }
-
-        if (sortDate == null) {
-            List<MetadataValue> createdValues = itemService.getMetadataByMetadataString(item, DATE_CREATED_FIELD);
-            if (createdValues != null) {
-                sortDate = firstParsableDate(createdValues);
-            }
-        }
-
-        if (sortDate != null) {
-            doc.addField(DATE_ISSUED_OR_CREATED_SORT_FIELD + "_dt", SolrUtils.getDateFormatter().format(sortDate));
-        }
-    }
-
-    private ZonedDateTime firstParsableDate(List<MetadataValue> metadataValues) {
-        for (MetadataValue metadataValue : metadataValues) {
-            if (metadataValue == null || StringUtils.isBlank(metadataValue.getValue())) {
-                continue;
-            }
-
-            ZonedDateTime parsedDate = MultiFormatDateParser.parse(metadataValue.getValue());
-            if (parsedDate != null) {
-                return parsedDate;
-            }
-        }
-
-        return null;
     }
 
     @Override

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -769,6 +769,7 @@
                         <ref bean="sortScore" />
                         <ref bean="sortTitle" />
                         <ref bean="sortDateIssued" />
+                        <ref bean="sortDateCreated" />
                         <ref bean="sortDateAccessioned"/>
                     </list>
                 </property>
@@ -3667,14 +3668,20 @@
         <property name="defaultSortOrder" value="asc"/>
     </bean>
 
+    <bean id="sortDateCreated" class="org.dspace.discovery.configuration.DiscoverySortFieldConfiguration">
+        <property name="metadataField" value="dc.date.created"/>
+        <property name="type" value="date"/>
+        <property name="defaultSortOrder" value="desc"/>
+    </bean>
+
     <bean id="sortDateIssuedOrCreatedDesc" class="org.dspace.discovery.configuration.DiscoverySortFieldConfiguration">
-        <property name="metadataField" value="dc.date.issued_or_created"/>
+        <property name="metadataField" value="sortDate"/>
         <property name="type" value="date"/>
         <property name="defaultSortOrder" value="desc"/>
     </bean>
 
     <bean id="sortDateIssuedOrCreatedAsc" class="org.dspace.discovery.configuration.DiscoverySortFieldConfiguration">
-        <property name="metadataField" value="dc.date.issued_or_created"/>
+        <property name="metadataField" value="sortDate"/>
         <property name="type" value="date"/>
         <property name="defaultSortOrder" value="asc"/>
     </bean>

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -303,8 +303,8 @@
                         <ref bean="sortScore" />
                         <ref bean="sortTitle" />
                         <ref bean="sortTitleDesc" />
-                        <ref bean="sortDateIssuedAsc" />
-                        <ref bean="sortDateIssued" />
+                        <ref bean="sortDateIssuedOrCreatedAsc" />
+                        <ref bean="sortDateIssuedOrCreatedDesc" />
                         <ref bean="sortDateAccessionedAsc" />
                         <ref bean="sortDateAccessioned" />
                     </list>
@@ -425,8 +425,8 @@
                         <ref bean="sortScore" />
                         <ref bean="sortTitle" />
                         <ref bean="sortTitleDesc" />
-                        <ref bean="sortDateIssuedAsc" />
-                        <ref bean="sortDateIssued" />
+                        <ref bean="sortDateIssuedOrCreatedAsc" />
+                        <ref bean="sortDateIssuedOrCreatedDesc" />
                         <ref bean="sortDateAccessionedAsc" />
                         <ref bean="sortDateAccessioned" />
                     </list>
@@ -445,8 +445,8 @@
                         <ref bean="sortScore" />
                         <ref bean="sortTitle" />
                         <ref bean="sortTitleDesc" />
-                        <ref bean="sortDateIssuedAsc" />
-                        <ref bean="sortDateIssued" />
+                        <ref bean="sortDateIssuedOrCreatedAsc" />
+                        <ref bean="sortDateIssuedOrCreatedDesc" />
                         <ref bean="sortDateAccessionedAsc" />
                         <ref bean="sortDateAccessioned" />
                     </list>
@@ -3663,6 +3663,18 @@
 
     <bean id="sortDateIssuedAsc" class="org.dspace.discovery.configuration.DiscoverySortFieldConfiguration">
         <property name="metadataField" value="dc.date.issued"/>
+        <property name="type" value="date"/>
+        <property name="defaultSortOrder" value="asc"/>
+    </bean>
+
+    <bean id="sortDateIssuedOrCreatedDesc" class="org.dspace.discovery.configuration.DiscoverySortFieldConfiguration">
+        <property name="metadataField" value="dc.date.issued_or_created"/>
+        <property name="type" value="date"/>
+        <property name="defaultSortOrder" value="desc"/>
+    </bean>
+
+    <bean id="sortDateIssuedOrCreatedAsc" class="org.dspace.discovery.configuration.DiscoverySortFieldConfiguration">
+        <property name="metadataField" value="dc.date.issued_or_created"/>
         <property name="type" value="date"/>
         <property name="defaultSortOrder" value="asc"/>
     </bean>

--- a/dspace/solr/search/conf/schema.xml
+++ b/dspace/solr/search/conf/schema.xml
@@ -295,6 +295,11 @@
      <!-- The database status of the current item -->
      <field name="database_status" type="string" indexed="true" stored="true" omitNorms="true" docValues="true" />
 
+    <!-- Campo para unificar las fechas de publicación y de creación al momento de indexar -->
+    <field name="sortDate_dt" type="date" indexed="true" stored="true" multiValued="true" omitNorms="true" docValues="true" />
+    <copyField source="dc.date.issued_dt" dest="sortDate_dt" />
+    <copyField source="dc.date.created_dt" dest="sortDate_dt" />
+
      <!-- Dynamic field used to store the relation metadata as a keywordFilter -->
      <dynamicField name="relation.*" type="keywordFilter" indexed="true" stored="true" omitNorms="true" multiValued="true"/>
 


### PR DESCRIPTION
Creo, desde el archivo de indexación de items, un metadato "virtual" que unifica los valores de issued y created, y permite utilizarlo para ordenar desde el discovery